### PR TITLE
chore: Update version to 0.1.3 and document housekeeping changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to MediaManager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.3] - 2025-11-30
+
+### Housekeeping
+- Code cleanup and maintenance
+
 ## [0.1.2] - 2025-11-30
 
 ### Changed
@@ -88,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Uses React 18 for UI components
 - Leverages WordPress REST API for all operations
 
+[0.1.3]: https://github.com/soderlind/mediamanager/releases/tag/v0.1.3
 [0.1.2]: https://github.com/soderlind/mediamanager/releases/tag/v0.1.2
 [0.1.1]: https://github.com/soderlind/mediamanager/releases/tag/v0.1.1
 [0.1.0]: https://github.com/soderlind/mediamanager/releases/tag/v0.1.0

--- a/mediamanager.php
+++ b/mediamanager.php
@@ -14,10 +14,12 @@
  * @wordpress-plugin
  * Plugin Name: Media Manager
  * Description: Virtual folder organization and smart management for the WordPress Media Library.
- * Version: 0.1.2
+ * Version: 0.1.3
  * Requires at least: 6.8
  * Requires PHP: 8.3
- * Author: Your Name
+ * Author: Per Soderlind
+ * Author URI: https://soderlind.no/
+ * License: GPL-2.0-or-later
  * Text Domain: mediamanager
  */
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mediamanager",
-	"version": "0.1.2",
+	"version": "0.1.3",
 	"description": "Virtual folder organization and smart management for the WordPress Media Library.",
 	"scripts": {
 		"build": "wp-scripts build",

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === Media Manager ===
-Contributors: persoderlind
+Contributors: PerS
 Tags: media, folders, organization, media library, virtual folders
 Requires at least: 6.8
 Tested up to: 6.8
-Stable tag: 0.1.2
+Stable tag: 0.1.3
 Requires PHP: 8.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -83,6 +83,9 @@ Media Manager works entirely within the WordPress admin. It doesn't affect your 
 
 == Changelog ==
 
+= 0.1.3 =
+* Housekeeping
+
 = 0.1.2 =
 * Changed: Refactored folder sidebar to share code between Media Library and Gutenberg modal
 * Changed: Created shared hooks and base components for folder tree
@@ -105,6 +108,9 @@ Media Manager works entirely within the WordPress admin. It doesn't affect your 
 * Norwegian Bokmål translation
 
 == Upgrade Notice ==
+
+= 0.1.3 =
+Housekeeping.
 
 = 0.1.2 =
 Refactored folder sidebar with shared components. Better UX after folder deletion.


### PR DESCRIPTION
This pull request is a minor release focused on housekeeping and general maintenance for the Media Manager plugin, updating metadata and documentation to reflect the new version 0.1.3. There are no functional or feature changes included.

Version and metadata updates:

* Bumped the plugin version from 0.1.2 to 0.1.3 in `mediamanager.php`, `package.json`, and `readme.txt`. Updated author information and added license details in `mediamanager.php`. [[1]](diffhunk://#diff-ee1e02dde2fe017b4864e3599a0eb21559e0390c7cc1700475b4a4d95c30ddb7L17-R22) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L2-R6)

Documentation updates:

* Added a changelog entry for version 0.1.3 noting the housekeeping and maintenance focus in both `CHANGELOG.md` and `readme.txt`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R86-R88)
* Updated the upgrade notice in `readme.txt` for version 0.1.3.
* Added a link to the 0.1.3 release in `CHANGELOG.md`.