### PR TITLE
feat: Add uninstall.php for clean plugin removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to MediaManager will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.16] - 2025-12-02
+
+### Added
+- `uninstall.php` for clean plugin removal - deletes all folders, settings, transients, and user meta when plugin is deleted
+
+### Changed
+- Updated folder structure in README.md to reflect PSR-4 changes from 0.1.4
+
 ## [0.1.15] - 2025-12-02
 
 ### Added
@@ -191,6 +199,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Leverages WordPress REST API for all operations
 
 
+[0.1.16]: https://github.com/soderlind/mediamanager/compare/0.1.15...0.1.16
 [0.1.15]: https://github.com/soderlind/mediamanager/compare/0.1.14...0.1.15
 [0.1.14]: https://github.com/soderlind/mediamanager/compare/0.1.13...0.1.14
 [0.1.13]: https://github.com/soderlind/mediamanager/compare/0.1.12...0.1.13

--- a/README.md
+++ b/README.md
@@ -82,22 +82,23 @@ When inserting media in the block editor:
 mediamanager/
 ├── build/              # Compiled assets
 ├── docs/               # Documentation
-├── includes/           # PHP classes
-│   ├── class-admin.php
-│   ├── class-editor.php
-│   ├── class-rest-api.php
-│   ├── class-settings.php
-│   ├── class-suggestions.php
-│   └── class-taxonomy.php
 ├── languages/          # Translation files
 ├── src/
+│   ├── Admin.php       # Media Library integration
+│   ├── Editor.php      # Gutenberg integration  
+│   ├── RestApi.php     # REST API endpoints
+│   ├── Settings.php    # Settings page
+│   ├── Suggestions.php # Smart suggestions
+│   ├── Taxonomy.php    # Custom taxonomy
 │   ├── admin/          # Media Library UI
 │   │   ├── components/ # React components
 │   │   └── styles/     # CSS
-│   └── editor/         # Gutenberg integration
+│   ├── editor/         # Gutenberg integration
+│   └── shared/         # Shared components & hooks
 ├── tests/
 │   ├── js/             # Vitest tests
 │   └── php/            # PHPUnit tests
+├── uninstall.php       # Cleanup on uninstall
 └── mediamanager.php    # Main plugin file
 ```
 

--- a/mediamanager.php
+++ b/mediamanager.php
@@ -14,7 +14,7 @@
  * @wordpress-plugin
  * Plugin Name: Media Manager
  * Description: Virtual folder organization and smart management for the WordPress Media Library.
- * Version: 0.1.15
+ * Version: 0.1.16
  * Requires at least: 6.8
  * Requires PHP: 8.3
  * Author: Per Soderlind

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mediamanager",
-	"version": "0.1.15",
+	"version": "0.1.16",
 	"description": "Virtual folder organization and smart management for the WordPress Media Library.",
 	"scripts": {
 		"build": "wp-scripts build",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: media, folders, organization, media library, virtual folders
 Requires at least: 6.8
 Tested up to: 6.9
-Stable tag: 0.1.15
+Stable tag: 0.1.16
 Requires PHP: 8.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -71,6 +71,10 @@ Only the folder organization is removed. Your media files are not deleted.
 Media Manager works entirely within the WordPress admin. It doesn't affect your front-end theme.
 
 == Changelog ==
+
+= 0.1.16 =
+* Added: uninstall.php for clean plugin removal (deletes folders, settings, transients, user meta)
+* Changed: Updated folder structure in README.md to reflect PSR-4 changes
 
 = 0.1.15 =
 * Added: Collapsing a parent folder now moves selection to the parent when a child folder is selected
@@ -146,6 +150,24 @@ Media Manager works entirely within the WordPress admin. It doesn't affect your 
 * Norwegian Bokmål translation
 
 == Upgrade Notice ==
+
+= 0.1.16 =
+Added uninstall.php for clean plugin removal.
+
+= 0.1.15 =
+Improved keyboard navigation: ArrowLeft moves to parent folder, collapsing parent selects it.
+
+= 0.1.14 =
+Edit Folder modal now allows moving folders to different parents.
+
+= 0.1.13 =
+New Show All Media setting. All settings now functional.
+
+= 0.1.12 =
+Jump to Folder After Move now defaults to disabled.
+
+= 0.1.11 =
+Fix: Moved files properly removed from source folder view.
 
 = 0.1.10 =
 Fix: Sort order is now preserved after moving files.

--- a/uninstall.php
+++ b/uninstall.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Uninstall Media Manager
+ *
+ * Removes all plugin data when the plugin is deleted via the WordPress admin.
+ * This file is called automatically by WordPress when the plugin is deleted.
+ *
+ * @package MediaManager
+ */
+
+// Exit if accessed directly or not in uninstall context.
+if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
+	exit;
+}
+
+/**
+ * Remove all Media Manager data.
+ *
+ * - Deletes all media_folder terms and their relationships
+ * - Removes plugin options from the options table
+ * - Cleans up any transients
+ */
+
+// Delete all terms in the media_folder taxonomy.
+$terms = get_terms(
+	array(
+		'taxonomy'   => 'media_folder',
+		'hide_empty' => false,
+		'fields'     => 'ids',
+	)
+);
+
+if ( ! is_wp_error( $terms ) && ! empty( $terms ) ) {
+	foreach ( $terms as $term_id ) {
+		wp_delete_term( $term_id, 'media_folder' );
+	}
+}
+
+// Delete plugin options.
+delete_option( 'mediamanager_settings' );
+
+// Delete any transients.
+delete_transient( 'mediamanager_folder_counts' );
+
+// Clean up user meta (sidebar visibility state).
+delete_metadata( 'user', 0, 'mediamanager_sidebar_visible', '', true );


### PR DESCRIPTION
This pull request introduces version 0.1.16 of Media Manager, focusing on improving plugin cleanup and updating documentation to reflect recent codebase changes. The most significant update is the addition of a comprehensive uninstall script to ensure all plugin data is removed when deleted. Documentation and metadata have also been updated to match the new version and folder structure.

**Plugin cleanup and removal:**
* Added `uninstall.php` to ensure clean removal of all plugin data, including media_folder taxonomy terms, plugin options, transients, and user meta.

**Documentation and metadata updates:**
* Updated `CHANGELOG.md` and `readme.txt` to document the new uninstall feature and the updated folder structure, with changelog and upgrade notices for 0.1.16. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R15) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R75-R78) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R154-R171)
* Revised the folder structure in `README.md` to reflect PSR-4 autoloading and recent file organization changes.
* Bumped the version number to 0.1.16 in `mediamanager.php`, `package.json`, and `readme.txt` for consistency across the project. [[1]](diffhunk://#diff-ee1e02dde2fe017b4864e3599a0eb21559e0390c7cc1700475b4a4d95c30ddb7L17-R17) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)
* Added a comparison link for version 0.1.16 to the bottom of `CHANGELOG.md`.