### PR TITLE
feat: Sort add-on tabs alphabetically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Virtual Media Folders will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.1] - 2026-01-16
+
+### Changed
+- Add-on tabs are now sorted alphabetically by title in the settings page
+
+### Documentation
+- Added comprehensive [Add-on Development Guide](docs/addon-development.md) with philosophy, architecture, and implementation details
+
 ## [1.6.0] - 2026-01-16
 
 ### Added
@@ -547,6 +555,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Uses React 18 for UI components
 - Leverages WordPress REST API for all operations
 
+[1.6.1]: https://github.com/soderlind/virtual-media-folders/compare/1.6.0...1.6.1
+[1.6.0]: https://github.com/soderlind/virtual-media-folders/compare/1.5.3...1.6.0
 [1.5.3]: https://github.com/soderlind/virtual-media-folders/compare/1.5.2...1.5.3
 [1.5.2]: https://github.com/soderlind/virtual-media-folders/compare/1.5.1...1.5.2
 [1.5.1]: https://github.com/soderlind/virtual-media-folders/compare/1.5.0...1.5.1

--- a/docs/addon-development.md
+++ b/docs/addon-development.md
@@ -147,6 +147,8 @@ add_filter( 'vmfo_settings_tabs', function( array $tabs ): array {
 });
 ```
 
+> **Note:** Tabs are automatically sorted alphabetically by title. The "General" tab always appears first, followed by add-on tabs in alphabetical order.
+
 ### Rendering Tab Content
 
 ```php

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtual-media-folders",
-	"version": "1.5.3",
+	"version": "1.6.1",
 	"description": "Virtual folder organization and smart management for the WordPress Media Library.",
 	"scripts": {
 		"build": "wp-scripts build",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: media, ai, organization, media library, virtual folders
 Requires at least: 6.8
 Tested up to: 6.9
-Stable tag: 1.6.0
+Stable tag: 1.6.1
 Requires PHP: 8.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -113,6 +113,10 @@ Only the folder organization is removed. Your media files are not deleted.
 Virtual Media Folders works entirely within the WordPress admin. It doesn't affect your front-end theme.
 
 == Changelog ==
+
+= 1.6.1 =
+* Changed: Add-on tabs are now sorted alphabetically by title in the settings page
+* Documentation: Added comprehensive [Add-on Development Guide](https://github.com/soderlind/virtual-media-folders/blob/main/docs/addon-development.md) with philosophy, architecture, and implementation details
 
 = 1.6.0 =
 * Added: Add-on Tab System - Settings page now supports tabs for add-on plugins

--- a/src/Settings.php
+++ b/src/Settings.php
@@ -444,7 +444,13 @@ final class Settings {
 		 * @param array $tabs Array of tabs: [ 'slug' => [ 'title' => '', 'callback' => callable ] ].
 		 */
 		$addon_tabs = apply_filters( 'vmfo_settings_tabs', array() );
-		$tabs       = array_merge( $tabs, $addon_tabs );
+
+		// Sort add-on tabs alphabetically by title.
+		uasort( $addon_tabs, function ( $a, $b ) {
+			return strcasecmp( $a[ 'title' ] ?? '', $b[ 'title' ] ?? '' );
+		} );
+
+		$tabs = array_merge( $tabs, $addon_tabs );
 
 		// Validate active tab exists, fall back to general.
 		if ( ! isset( $tabs[ $active_tab ] ) ) {

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'soderlind/virtual-media-folders',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'ee6c16fb028aab2c16705b845a81415ef5e20cd3',
+        'reference' => 'db1fae1864414e7cf7b5f9ebd1d19107dceb2e3b',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'soderlind/virtual-media-folders' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'ee6c16fb028aab2c16705b845a81415ef5e20cd3',
+            'reference' => 'db1fae1864414e7cf7b5f9ebd1d19107dceb2e3b',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/virtual-media-folders.php
+++ b/virtual-media-folders.php
@@ -14,7 +14,7 @@
  * @wordpress-plugin
  * Plugin Name: Virtual Media Folders
  * Description: Virtual folder organization and smart management for the WordPress Media Library.
- * Version: 1.6.0
+ * Version: 1.6.1
  * Requires at least: 6.8
  * Requires PHP: 8.3
  * Author: Per Soderlind


### PR DESCRIPTION
This pull request releases version 1.6.1 of Virtual Media Folders, introducing an improvement to the settings page by sorting add-on tabs alphabetically and providing enhanced documentation for add-on developers. The update is reflected across documentation, metadata, and implementation.

**Settings Page Improvements:**
* Add-on tabs in the settings page are now automatically sorted alphabetically by title, with the "General" tab always first. This change improves usability and consistency for users managing multiple add-ons. [[1]](diffhunk://#diff-eb1710f64250974d6d1550d421a31054e6079592ae3a8428cd9530bc086bdd94R447-R452) [[2]](diffhunk://#diff-d0abbbd2ceb7cf686c58c1c89d45091ed24a64da5d4ae0bf252cc7fb4e3a35f0R150-R151)

**Documentation Updates:**
* A comprehensive Add-on Development Guide (`docs/addon-development.md`) has been added, covering philosophy, architecture, and implementation details for developers.

**Release and Metadata Updates:**
* Bumped version to 1.6.1 in `package.json`, `virtual-media-folders.php`, and `readme.txt`, and updated changelogs and stable tag references to reflect the new release and its changes. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-e59373c6735cd495bd143c9b95e1a2405e8d255e742486da10bc8633a2367473L17-R17) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R117-R120) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR558-R559)