### PR TITLE
feat: Enhance error handling in REST API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Virtual Media Folders will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.4] - 2026-01-23
+
+### Fixed
+- REST API now returns proper 400 status code instead of 500 when creating duplicate folders
+- Error messages now use "folder" terminology instead of "term" for better user experience
+
 ## [1.6.3] - 2026-01-22
 
 ### Fixed
@@ -579,6 +585,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Requires PHP 7.4+
 - Uses React 18 for UI components
 - Leverages WordPress REST API for all operations
+[1.6.4]: https://github.com/soderlind/virtual-media-folders/compare/1.6.3...1.6.4
 [1.6.3]: https://github.com/soderlind/virtual-media-folders/compare/1.6.2...1.6.3
 [1.6.2]: https://github.com/soderlind/virtual-media-folders/compare/1.6.1...1.6.2
 [1.6.1]: https://github.com/soderlind/virtual-media-folders/compare/1.6.0...1.6.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtual-media-folders",
-	"version": "1.6.3",
+	"version": "1.6.4",
 	"description": "Virtual folder organization and smart management for the WordPress Media Library.",
 	"scripts": {
 		"build": "wp-scripts build",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: media, ai, organization, media library, virtual folders
 Requires at least: 6.8
 Tested up to: 6.9
-Stable tag: 1.6.3
+Stable tag: 1.6.4
 Requires PHP: 8.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -113,6 +113,10 @@ Only the folder organization is removed. Your media files are not deleted.
 Virtual Media Folders works entirely within the WordPress admin. It doesn't affect your front-end theme.
 
 == Changelog ==
+
+= 1.6.4 =
+* Fixed: REST API now returns proper 400 status code instead of 500 when creating duplicate folders
+* Fixed: Error messages now use "folder" terminology instead of "term" for better user experience
 
 = 1.6.3 =
 * Fixed: Folder counts now update automatically when media is deleted (single or bulk delete)

--- a/src/RestApi.php
+++ b/src/RestApi.php
@@ -428,7 +428,24 @@ final class RestApi extends WP_REST_Controller {
 		);
 
 		if ( is_wp_error( $result ) ) {
-			return $result;
+			$error_code = $result->get_error_code();
+
+			// Map WordPress term errors to user-friendly folder messages.
+			$error_messages = [
+				'term_exists'       => __( 'A folder with this name already exists.', 'virtual-media-folders' ),
+				'empty_term_name'   => __( 'Folder name cannot be empty.', 'virtual-media-folders' ),
+				'invalid_term'      => __( 'Invalid folder.', 'virtual-media-folders' ),
+				'invalid_taxonomy'  => __( 'Invalid folder taxonomy.', 'virtual-media-folders' ),
+				'parent_not_exists' => __( 'Parent folder does not exist.', 'virtual-media-folders' ),
+			];
+
+			$message = $error_messages[ $error_code ] ?? $result->get_error_message();
+
+			return new WP_Error(
+				$error_code,
+				$message,
+				[ 'status' => 400 ]
+			);
 		}
 
 		$term = get_term( $result[ 'term_id' ], Taxonomy::TAXONOMY );
@@ -477,7 +494,24 @@ final class RestApi extends WP_REST_Controller {
 		$result = wp_update_term( $folder_id, Taxonomy::TAXONOMY, $args );
 
 		if ( is_wp_error( $result ) ) {
-			return $result;
+			$error_code = $result->get_error_code();
+
+			// Map WordPress term errors to user-friendly folder messages.
+			$error_messages = [
+				'term_exists'       => __( 'A folder with this name already exists.', 'virtual-media-folders' ),
+				'empty_term_name'   => __( 'Folder name cannot be empty.', 'virtual-media-folders' ),
+				'invalid_term'      => __( 'Invalid folder.', 'virtual-media-folders' ),
+				'invalid_taxonomy'  => __( 'Invalid folder taxonomy.', 'virtual-media-folders' ),
+				'parent_not_exists' => __( 'Parent folder does not exist.', 'virtual-media-folders' ),
+			];
+
+			$message = $error_messages[ $error_code ] ?? $result->get_error_message();
+
+			return new WP_Error(
+				$error_code,
+				$message,
+				[ 'status' => 400 ]
+			);
 		}
 
 		$term = get_term( $result[ 'term_id' ], Taxonomy::TAXONOMY );
@@ -502,7 +536,21 @@ final class RestApi extends WP_REST_Controller {
 		$result = wp_delete_term( $folder_id, Taxonomy::TAXONOMY );
 
 		if ( is_wp_error( $result ) ) {
-			return $result;
+			$error_code = $result->get_error_code();
+
+			// Map WordPress term errors to user-friendly folder messages.
+			$error_messages = [
+				'invalid_term'     => __( 'Invalid folder.', 'virtual-media-folders' ),
+				'invalid_taxonomy' => __( 'Invalid folder taxonomy.', 'virtual-media-folders' ),
+			];
+
+			$message = $error_messages[ $error_code ] ?? $result->get_error_message();
+
+			return new WP_Error(
+				$error_code,
+				$message,
+				[ 'status' => 400 ]
+			);
 		}
 
 		if ( ! $result ) {

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -7,4 +7,10 @@ $baseDir = dirname($vendorDir);
 
 return array(
     'Composer\\InstalledVersions' => $vendorDir . '/composer/InstalledVersions.php',
+    'VirtualMediaFolders\\Admin' => $baseDir . '/src/Admin.php',
+    'VirtualMediaFolders\\Editor' => $baseDir . '/src/Editor.php',
+    'VirtualMediaFolders\\RestApi' => $baseDir . '/src/RestApi.php',
+    'VirtualMediaFolders\\Settings' => $baseDir . '/src/Settings.php',
+    'VirtualMediaFolders\\Suggestions' => $baseDir . '/src/Suggestions.php',
+    'VirtualMediaFolders\\Taxonomy' => $baseDir . '/src/Taxonomy.php',
 );

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -22,6 +22,12 @@ class ComposerStaticInit9da11f50a84c12ea0f2b8e42c40880be
 
     public static $classMap = array (
         'Composer\\InstalledVersions' => __DIR__ . '/..' . '/composer/InstalledVersions.php',
+        'VirtualMediaFolders\\Admin' => __DIR__ . '/../..' . '/src/Admin.php',
+        'VirtualMediaFolders\\Editor' => __DIR__ . '/../..' . '/src/Editor.php',
+        'VirtualMediaFolders\\RestApi' => __DIR__ . '/../..' . '/src/RestApi.php',
+        'VirtualMediaFolders\\Settings' => __DIR__ . '/../..' . '/src/Settings.php',
+        'VirtualMediaFolders\\Suggestions' => __DIR__ . '/../..' . '/src/Suggestions.php',
+        'VirtualMediaFolders\\Taxonomy' => __DIR__ . '/../..' . '/src/Taxonomy.php',
     );
 
     public static function getInitializer(ClassLoader $loader)

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'soderlind/virtual-media-folders',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'bae558de79e7fbb28b316e31993260a3557769b3',
+        'reference' => 'cff621780091e4742d6134a4c2d8c0cb35a344cb',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'soderlind/virtual-media-folders' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'bae558de79e7fbb28b316e31993260a3557769b3',
+            'reference' => 'cff621780091e4742d6134a4c2d8c0cb35a344cb',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/virtual-media-folders.php
+++ b/virtual-media-folders.php
@@ -14,7 +14,7 @@
  * @wordpress-plugin
  * Plugin Name: Virtual Media Folders
  * Description: Virtual folder organization and smart management for the WordPress Media Library.
- * Version: 1.6.3
+ * Version: 1.6.4
  * Requires at least: 6.8
  * Requires PHP: 8.3
  * Author: Per Soderlind


### PR DESCRIPTION
This pull request updates the Virtual Media Folders plugin to version 1.6.4, focusing on improving error handling in the REST API and enhancing user experience by providing clearer, folder-specific error messages. The update ensures that duplicate folder creation and other folder-related errors now return proper HTTP status codes and user-friendly messages. Documentation and metadata have also been updated to reflect the new version.

**REST API Error Handling Improvements:**

* The REST API now returns a 400 status code (instead of 500) when attempting to create a duplicate folder, aligning with expected client error responses.
* Error messages throughout folder creation, update, and deletion operations now use "folder" terminology instead of the more technical "term," making them clearer for users. [[1]](diffhunk://#diff-836e43c9a2be18666079914e28fa4baec044da7aabb6a7b5125e7deb74ced9aaL431-R448) [[2]](diffhunk://#diff-836e43c9a2be18666079914e28fa4baec044da7aabb6a7b5125e7deb74ced9aaL480-R514) [[3]](diffhunk://#diff-836e43c9a2be18666079914e28fa4baec044da7aabb6a7b5125e7deb74ced9aaL505-R553)

**Documentation and Versioning Updates:**

* Updated `CHANGELOG.md` and `readme.txt` with details of the 1.6.4 release, highlighting the improved error handling and terminology changes. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR588) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R117-R120)
* Bumped version numbers in `package.json`, `readme.txt`, and `virtual-media-folders.php` to 1.6.4. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[3]](diffhunk://#diff-e59373c6735cd495bd143c9b95e1a2405e8d255e742486da10bc8633a2367473L17-R17)