### PR TITLE
chore: Bump version to 1.6.7 and update dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Virtual Media Folders will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.7] - 2026-01-23
+
+### Changed
+- Updated @wordpress/scripts to 31.3.0
+- Updated vitest to 4.0.18
+
 ## [1.6.6] - 2026-01-23
 
 ### Added
@@ -605,13 +611,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Requires PHP 7.4+
 - Uses React 18 for UI components
 - Leverages WordPress REST API for all operations
-[1.6.5]: https://github.com/soderlind/virtual-media-folders/compare/1.6.4...1.6.5
-[1.6.4]: https://github.com/soderlind/virtual-media-folders/compare/1.6.3...1.6.4
-[1.6.3]: https://github.com/soderlind/virtual-media-folders/compare/1.6.2...1.6.3
-[1.6.2]: https://github.com/soderlind/virtual-media-folders/compare/1.6.1...1.6.2
-[1.6.1]: https://github.com/soderlind/virtual-media-folders/compare/1.6.0...1.6.1
-[1.6.0]: https://github.com/soderlind/virtual-media-folders/compare/1.5.3...1.6.0
-[1.5.3]: https://github.com/soderlind/virtual-media-folders/compare/1.5.2...1.5.3
+[1.6.7]: https://github.com/soderlind/virtual-media-folders/compare/1.6.6...1.6.7
 [1.6.6]: https://github.com/soderlind/virtual-media-folders/compare/1.6.5...1.6.6
 [1.6.5]: https://github.com/soderlind/virtual-media-folders/compare/1.6.4...1.6.5
 [1.6.4]: https://github.com/soderlind/virtual-media-folders/compare/1.6.3...1.6.4

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "virtual-media-folders",
-	"version": "1.3.7",
+	"version": "1.6.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "virtual-media-folders",
-			"version": "1.3.7",
+			"version": "1.6.6",
 			"dependencies": {
 				"@dnd-kit/core": "^6.3.1",
 				"@dnd-kit/modifiers": "^9.0.0",
@@ -23,11 +23,11 @@
 				"@testing-library/react": "^14.0.0",
 				"@testing-library/user-event": "^14.6.1",
 				"@vitejs/plugin-react": "^5.1.2",
-				"@wordpress/scripts": "^31.2.0",
+				"@wordpress/scripts": "^31.3.0",
 				"jsdom": "^24.0.0",
 				"react": "^18.3.1",
 				"react-dom": "^18.3.1",
-				"vitest": "^4.0.16"
+				"vitest": "^4.0.18"
 			}
 		},
 		"node_modules/@adobe/css-tools": {
@@ -1915,26 +1915,26 @@
 			}
 		},
 		"node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.0.tgz",
-			"integrity": "sha512-KT01GjzV6AQD5+IYrcpoYLkCu1Jod3nau1Z7EsEuViO3TZGRacSbO9MfHmbJ1WaOXFtWLxPVj169cn2WNKPkIg==",
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+			"integrity": "sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hashery": "^1.2.0",
-				"hookified": "^1.13.0"
+				"hashery": "^1.4.0",
+				"hookified": "^1.15.0"
 			},
 			"engines": {
 				"node": ">= 18"
 			},
 			"peerDependencies": {
-				"keyv": "^5.5.4"
+				"keyv": "^5.6.0"
 			}
 		},
 		"node_modules/@cacheable/memory/node_modules/keyv": {
-			"version": "5.5.5",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
-			"integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1953,9 +1953,9 @@
 			}
 		},
 		"node_modules/@cacheable/utils/node_modules/keyv": {
-			"version": "5.5.5",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
-			"integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2050,9 +2050,9 @@
 			}
 		},
 		"node_modules/@csstools/css-syntax-patches-for-csstree": {
-			"version": "1.0.22",
-			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.22.tgz",
-			"integrity": "sha512-qBcx6zYlhleiFfdtzkRgwNC7VVoAwfK76Vmsw5t+PbvtdknO9StgRk7ROvq9so1iqbdW4uLIDAsXRsTfUrIoOw==",
+			"version": "1.0.25",
+			"resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.25.tgz",
+			"integrity": "sha512-g0Kw9W3vjx5BEBAF8c5Fm2NcB/Fs8jJXh85aXqwEXiL+tqtOut07TWgyaGzAAfTM+gKckrrncyeGEZPcaRgm2Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -2198,9 +2198,9 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
-			"integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.8.1.tgz",
+			"integrity": "sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -2210,9 +2210,9 @@
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.7.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
-			"integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.8.1.tgz",
+			"integrity": "sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -2818,9 +2818,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.9.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-			"integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4462,9 +4462,9 @@
 			}
 		},
 		"node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.38.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
-			"integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
+			"version": "1.39.0",
+			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
+			"integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -4818,14 +4818,14 @@
 			}
 		},
 		"node_modules/@playwright/test": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.57.0.tgz",
-			"integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
+			"version": "1.58.0",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
+			"integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright": "1.57.0"
+				"playwright": "1.58.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -6131,11 +6131,13 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "24.10.1",
+			"version": "20.19.30",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.30.tgz",
+			"integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"undici-types": "~7.16.0"
+				"undici-types": "~6.21.0"
 			}
 		},
 		"node_modules/@types/node-forge": {
@@ -6890,16 +6892,16 @@
 			}
 		},
 		"node_modules/@vitest/expect": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.16.tgz",
-			"integrity": "sha512-eshqULT2It7McaJkQGLkPjPjNph+uevROGuIMJdG3V+0BSR2w9u6J9Lwu+E8cK5TETlfou8GRijhafIMhXsimA==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+			"integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@standard-schema/spec": "^1.0.0",
 				"@types/chai": "^5.2.2",
-				"@vitest/spy": "4.0.16",
-				"@vitest/utils": "4.0.16",
+				"@vitest/spy": "4.0.18",
+				"@vitest/utils": "4.0.18",
 				"chai": "^6.2.1",
 				"tinyrainbow": "^3.0.3"
 			},
@@ -6908,13 +6910,13 @@
 			}
 		},
 		"node_modules/@vitest/mocker": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.16.tgz",
-			"integrity": "sha512-yb6k4AZxJTB+q9ycAvsoxGn+j/po0UaPgajllBgt1PzoMAAmJGYFdDk0uCcRcxb3BrME34I6u8gHZTQlkqSZpg==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+			"integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/spy": "4.0.16",
+				"@vitest/spy": "4.0.18",
 				"estree-walker": "^3.0.3",
 				"magic-string": "^0.30.21"
 			},
@@ -6935,9 +6937,9 @@
 			}
 		},
 		"node_modules/@vitest/pretty-format": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.16.tgz",
-			"integrity": "sha512-eNCYNsSty9xJKi/UdVD8Ou16alu7AYiS2fCPRs0b1OdhJiV89buAXQLpTbe+X8V9L6qrs9CqyvU7OaAopJYPsA==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+			"integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6948,13 +6950,13 @@
 			}
 		},
 		"node_modules/@vitest/runner": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.16.tgz",
-			"integrity": "sha512-VWEDm5Wv9xEo80ctjORcTQRJ539EGPB3Pb9ApvVRAY1U/WkHXmmYISqU5E79uCwcW7xYUV38gwZD+RV755fu3Q==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+			"integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/utils": "4.0.16",
+				"@vitest/utils": "4.0.18",
 				"pathe": "^2.0.3"
 			},
 			"funding": {
@@ -6962,13 +6964,13 @@
 			}
 		},
 		"node_modules/@vitest/snapshot": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.16.tgz",
-			"integrity": "sha512-sf6NcrYhYBsSYefxnry+DR8n3UV4xWZwWxYbCJUt2YdvtqzSPR7VfGrY0zsv090DAbjFZsi7ZaMi1KnSRyK1XA==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+			"integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.0.16",
+				"@vitest/pretty-format": "4.0.18",
 				"magic-string": "^0.30.21",
 				"pathe": "^2.0.3"
 			},
@@ -6977,9 +6979,9 @@
 			}
 		},
 		"node_modules/@vitest/spy": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.16.tgz",
-			"integrity": "sha512-4jIOWjKP0ZUaEmJm00E0cOBLU+5WE0BpeNr3XN6TEF05ltro6NJqHWxXD0kA8/Zc8Nh23AT8WQxwNG+WeROupw==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+			"integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -6987,13 +6989,13 @@
 			}
 		},
 		"node_modules/@vitest/utils": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.16.tgz",
-			"integrity": "sha512-h8z9yYhV3e1LEfaQ3zdypIrnAg/9hguReGZoS7Gl0aBG5xgA410zBqECqmaF/+RkTggRsfnzc1XaAHA6bmUufA==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+			"integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/pretty-format": "4.0.16",
+				"@vitest/pretty-format": "4.0.18",
 				"tinyrainbow": "^3.0.3"
 			},
 			"funding": {
@@ -7199,9 +7201,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.37.0.tgz",
-			"integrity": "sha512-tPLa2YFAau+gT2zKovRK5DRiJchsKgNFiuElIWeKYkLytkyws9fQAgjF/AkDFFxRMdDocNfCscpKWhp79+tIFA==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.38.0.tgz",
+			"integrity": "sha512-5DxPlGcB2EDpZjYI9FD1rOcYRaYuPr9EXNhDsiX+Mbxgj6ZZvWeJAT+E/8YlAOO969skUjxk/BIScQRSE99HbA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -7211,8 +7213,8 @@
 				"@babel/plugin-transform-runtime": "7.25.7",
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
-				"@wordpress/browserslist-config": "^6.37.0",
-				"@wordpress/warning": "^3.37.0",
+				"@wordpress/browserslist-config": "^6.38.0",
+				"@wordpress/warning": "^3.38.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -7429,9 +7431,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.13.0.tgz",
-			"integrity": "sha512-+APLd5GqzzJ/atVVs3LGPcCRRy8mVfVQi1QY+cseNAQbRe4LvsDarLbzkblWEwuksxgUGmVGDC3fDNxrwszJ2A==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.14.0.tgz",
+			"integrity": "sha512-0NoWb5+gVGUMZ8RiAE4g4dJ08ZdSMrWdnt/fp//BclezTdOLepZPzZ9O6nDWLVdlNgnYLhPwK/t5jxOow5WRoA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -7439,9 +7441,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.37.0.tgz",
-			"integrity": "sha512-L//FRak9bo+sDLAignC4QkhITHgeFVlL0C4lWI/AM+AIHKGrHT4LOdwwNpYWMkkztW9rxHRptGkF/JDxuCakxQ==",
+			"version": "6.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.38.0.tgz",
+			"integrity": "sha512-cLm8mg7jHdajpkuC0ohjy1/DWB7X/mrW8N5spA0ukKfj+CbJi7+PVFeeEPCjDLEybnlqrVCJ8VaLaxde+xU3UA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7580,9 +7582,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.37.0.tgz",
-			"integrity": "sha512-N9DTLr07AYV9vo/kFVSKYp/+wg2wBHL4ekDldwx2rGNtOHjoSi1oo+iBmStSaKMRtCQX2Xq8xVFH04+53T0yXA==",
+			"version": "6.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.38.0.tgz",
+			"integrity": "sha512-N/wjZ7Ne5D3ASXgEqKhLeAsbYPUtmSAXmyd31dMChIP6HnN9kuN+iyrxNR3COg2VoW7K9VAhwTzEEGQrOQv/rw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -7634,9 +7636,9 @@
 			}
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.37.0.tgz",
-			"integrity": "sha512-H77He9+sPNchzbEeFk2YSuYW5JNk3oHnlXJ1EVPUHpIZTr6gM80AGBuxP/W4WtWdLn0A5/TxCmTAxsN1M8YVvQ==",
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.38.0.tgz",
+			"integrity": "sha512-/3Qo6/N5BtCbQJJShy3pY5xr68OkMctouYcz1mvL8Q8tMO1fdiZTlJvU9bSMwdM1G1NEbE8pa/9q2F1Va/2S2A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -7651,18 +7653,19 @@
 				"npm": ">=8.19.2"
 			},
 			"peerDependencies": {
-				"@playwright/test": ">=1"
+				"@playwright/test": ">=1",
+				"@types/node": "^20.17.10"
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.36.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.36.0.tgz",
-			"integrity": "sha512-6Ym/Ucik49skz1XJ2GRXENoMjJx7EYnY+fbfor9KtChiCd9/3H4/rI4sZgewVPIO//fCKEk7G30HoR+xB7GZMQ==",
+			"version": "6.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.38.0.tgz",
+			"integrity": "sha512-4N9xtuE2TIvaZ037fQREKrBw4TTt90PWswAfNFvxUVu5vdp91PLuR6rmeO0ohKg2CJLzozQLEKZF+6VuSaYowQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@types/react": "^18.2.79",
-				"@types/react-dom": "^18.2.25",
-				"@wordpress/escape-html": "^3.36.0",
+				"@types/react": "^18.3.27",
+				"@types/react-dom": "^18.3.1",
+				"@wordpress/escape-html": "^3.38.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -7674,7 +7677,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.36.0",
+			"version": "3.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.38.0.tgz",
+			"integrity": "sha512-LItqIdFnn/JAVEzTtvDZGJfsdmzeIE4ryMjovHkJhRElzcQWKHuq806DMprL40NcvJbdn0YfJZSv+aeP+9Ah3g==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -7682,17 +7687,18 @@
 			}
 		},
 		"node_modules/@wordpress/eslint-plugin": {
-			"version": "23.0.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-23.0.0.tgz",
-			"integrity": "sha512-fdgBWc7jC0JKi8j16lt51F3Sp02n7emSU3af5UFnQ5feXyJSO3mGcVJzZDpehL3ts/Clhu3II+CYOlUeek4H8g==",
+			"version": "24.0.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-24.0.0.tgz",
+			"integrity": "sha512-FXf427hQNXymMxk+qvzejXLEnnn64aGNHBEDMUYpt4MJx98+Upo2uYG0JGWm5y/Aqm+rBlGgdyNsQjjSB+Q6pQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/eslint-parser": "7.25.7",
 				"@typescript-eslint/eslint-plugin": "^6.4.1",
 				"@typescript-eslint/parser": "^6.4.1",
-				"@wordpress/babel-preset-default": "^8.37.0",
-				"@wordpress/prettier-config": "^4.37.0",
+				"@wordpress/babel-preset-default": "^8.38.0",
+				"@wordpress/prettier-config": "^4.38.0",
+				"@wordpress/theme": "^0.5.0",
 				"cosmiconfig": "^7.0.0",
 				"eslint-config-prettier": "^8.3.0",
 				"eslint-import-resolver-typescript": "^4.4.4",
@@ -7788,13 +7794,14 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.37.0.tgz",
-			"integrity": "sha512-RTNy0qg1sQLRunqsWjCAR8Nw2RZ62DSIaf09J6xzmuYdFjdvsmeQWs0OSs9e6mVQftxqDgJ/V4NQ1ctLxZM06w==",
+			"version": "8.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.38.0.tgz",
+			"integrity": "sha512-pRvWbxr/PHs2IsjsVvb9kBgqcxOcPnTN/baOmmEJFHVtOa5hp/ze6zbz/c18RCmrxWt5doRwHpfH84M/yivo2A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"jest-matcher-utils": "^29.6.2"
+				"jest-matcher-utils": "^29.6.2",
+				"jest-mock": "^29.6.2"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -7805,13 +7812,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.37.0.tgz",
-			"integrity": "sha512-AaT02lS2a/FnD/arYSSc1TkbIlLd1zXY40YqGtpYz1/MqJKoje6th/RZGOMQKC1pyXt5KKBzSFMD4Av39CxThw==",
+			"version": "12.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.38.0.tgz",
+			"integrity": "sha512-rAEYTMbpmfhYA5p3HmkhsTXM3rHq+4mdmt8xS5izXn5SzZdsHs+oa1Ej9COMi6xThpMN5i0+N+vz3HDzAMLCsg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.37.0",
+				"@wordpress/jest-console": "^8.38.0",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -7835,9 +7842,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.37.0.tgz",
-			"integrity": "sha512-Ond/mR+fw+8JMlcMmj1MBjVgQKD7GVYlL3Ww1n1/yBpRS9OP+UECF4vES3rdEqvL8TU+O/cvoWFpNY2DWO4P8w==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.38.0.tgz",
+			"integrity": "sha512-/8oarSArKiN2ZUTCexn27YQLPXpxmNAYQEzgubmALtR5wGWnMwpCw9bt/+/cG6t6o1YaAN8ZOO3gattQYssYrA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7849,13 +7856,13 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.37.0.tgz",
-			"integrity": "sha512-6+/aFPjr3AhmiBQEZs/huG3pkHPUHwwqwS8IIUqwDFuXnX3RkqRJvIoLdfDyR04QaFamyk1IoRv01zU0pZB8YA==",
+			"version": "5.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.38.0.tgz",
+			"integrity": "sha512-I8QFM8pPv04VTvakhIqRL5CU8s6Irf7onixBjXD95+ae3kmVJY548mp7cBU5MV9n92IZbGbwLjhaOIegS3QxfQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^6.13.0",
+				"@wordpress/base-styles": "^6.14.0",
 				"autoprefixer": "^10.4.20",
 				"postcss-import": "^16.1.1"
 			},
@@ -7868,9 +7875,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.37.0.tgz",
-			"integrity": "sha512-5l+5q07DXpoMhGWxVjJqb60RFyspaD7twCnnVWzqfFNUfKWptytMj3KYV3oO9+4ONWehsEzRF9zl3ai+S6ztvg==",
+			"version": "4.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.38.0.tgz",
+			"integrity": "sha512-kWGpmmkIvvObtteeOBkZM3GiTOL8tBkccBJwIWV7kBIC71HrBERnvQZKga84QW5thdt+S0ccjBZk41saEGXavw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -7908,7 +7915,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.36.0",
+			"version": "1.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.38.0.tgz",
+			"integrity": "sha512-6Hj9x3xJb64Xu/p2M4XA9fGeY2omTly2bb+Kayaa55eEZi6iXlcIhvv7UAdKhJ2PF9hfuENccgqhG7OrvaEEJg==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -7955,25 +7964,25 @@
 			}
 		},
 		"node_modules/@wordpress/scripts": {
-			"version": "31.2.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-31.2.0.tgz",
-			"integrity": "sha512-0BKF/aWGX2MegnsgxNkoKQCIlZzvzc/w9noC0hCsNCQqgTolP+idtr8sBA3J2E5gP3ieGk4DCr9CbAtLjkP23g==",
+			"version": "31.3.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-31.3.0.tgz",
+			"integrity": "sha512-gZiw7y3/tNbzxcW4IXBszyTzP7KkZivDGAvL01sJ1bcVTTuD4LyQ4MXhesCUYEYXPkSRNQh1Q4oAXk1FH3DlSQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@babel/core": "7.25.7",
 				"@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
 				"@svgr/webpack": "^8.0.1",
-				"@wordpress/babel-preset-default": "^8.37.0",
-				"@wordpress/browserslist-config": "^6.37.0",
-				"@wordpress/dependency-extraction-webpack-plugin": "^6.37.0",
-				"@wordpress/e2e-test-utils-playwright": "^1.37.0",
-				"@wordpress/eslint-plugin": "^23.0.0",
-				"@wordpress/jest-preset-default": "^12.37.0",
-				"@wordpress/npm-package-json-lint-config": "^5.37.0",
-				"@wordpress/postcss-plugins-preset": "^5.37.0",
-				"@wordpress/prettier-config": "^4.37.0",
-				"@wordpress/stylelint-config": "^23.29.0",
+				"@wordpress/babel-preset-default": "^8.38.0",
+				"@wordpress/browserslist-config": "^6.38.0",
+				"@wordpress/dependency-extraction-webpack-plugin": "^6.38.0",
+				"@wordpress/e2e-test-utils-playwright": "^1.38.0",
+				"@wordpress/eslint-plugin": "^24.0.0",
+				"@wordpress/jest-preset-default": "^12.38.0",
+				"@wordpress/npm-package-json-lint-config": "^5.38.0",
+				"@wordpress/postcss-plugins-preset": "^5.38.0",
+				"@wordpress/prettier-config": "^4.38.0",
+				"@wordpress/stylelint-config": "^23.30.0",
 				"adm-zip": "^0.5.9",
 				"babel-jest": "29.7.0",
 				"babel-loader": "9.2.1",
@@ -7986,7 +7995,7 @@
 				"cssnano": "^6.0.1",
 				"cwd": "^0.10.0",
 				"dir-glob": "^3.0.1",
-				"eslint": "^8.3.0",
+				"eslint": "^8.57.1",
 				"expect-puppeteer": "^4.4.0",
 				"fast-glob": "^3.2.7",
 				"filenamify": "^4.2.0",
@@ -8083,13 +8092,14 @@
 			}
 		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.29.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.29.0.tgz",
-			"integrity": "sha512-TTT2oc9Fw2rdnCs4bzI2EHRXgODT3YggjcewqxbBcioPsiAOff9E9gp6NZhe2VlZjVsDcwabUs6m4RIgbBSKaQ==",
+			"version": "23.30.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.30.0.tgz",
+			"integrity": "sha512-35s8w52ZxTVkvllBSCMbV2cFLQjHd+8FzROUIBW0OaUlZum3bQXnz2I3Q71e6fG2/jXvXVrHRh45P2oIhWnKPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@stylistic/stylelint-plugin": "^3.0.1",
+				"@wordpress/theme": "^0.5.0",
 				"stylelint-config-recommended": "^14.0.1",
 				"stylelint-config-recommended-scss": "^14.1.0"
 			},
@@ -8100,6 +8110,33 @@
 			"peerDependencies": {
 				"stylelint": "^16.8.2",
 				"stylelint-scss": "^6.4.0"
+			}
+		},
+		"node_modules/@wordpress/theme": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.5.0.tgz",
+			"integrity": "sha512-6V14snLXUqVs3fBPmGJhWkgtWcrwEe7vUS04nTl7hyI5uyL+N7LXRldWTjnzwaQL0ywBIx4u13gJU/GZqOc8dQ==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.38.0",
+				"@wordpress/private-apis": "^1.38.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/undo-manager": {
@@ -8125,9 +8162,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.37.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.37.0.tgz",
-			"integrity": "sha512-oXWyKiYJIa9SuPRNEJiOWn2Qk0RzfxOsDqXcus1OL44swCRtSM+ypm16CJpRhZpMUcsJ6d23PBxTC97C/iiJpQ==",
+			"version": "3.38.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.38.0.tgz",
+			"integrity": "sha512-4eHJoNC/Ofrp+hOIf/2KqSoyIZLFIoyAhfTBrFxq3bGKNFJlOEHAJ3+tGiy77Ja93uQzrSWctZsH1CpSRYKkng==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -8748,9 +8785,9 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.11.0",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.0.tgz",
-			"integrity": "sha512-ilYanEU8vxxBexpJd8cWM4ElSQq4QctCLKih0TSfjIfCQTeyH/6zVrmIJfLPrKTKJRbiG+cfnZbQIjAlJmF1jQ==",
+			"version": "4.11.1",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.1.tgz",
+			"integrity": "sha512-BASOg+YwO2C+346x3LZOeoovTIoTrRqEsqMa6fmfAV0P+U9mFr9NsyOEpiYvFjbc64NMrSswhV50WdXzdb/Z5A==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"engines": {
@@ -9309,23 +9346,23 @@
 			}
 		},
 		"node_modules/cacheable": {
-			"version": "2.3.1",
-			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.1.tgz",
-			"integrity": "sha512-yr+FSHWn1ZUou5LkULX/S+jhfgfnLbuKQjE40tyEd4fxGZVMbBL5ifno0J0OauykS8UiCSgHi+DV/YD+rjFxFg==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.2.tgz",
+			"integrity": "sha512-w+ZuRNmex9c1TR9RcsxbfTKCjSL0rh1WA5SABbrWprIHeNBdmyQLSYonlDy9gpD+63XT8DgZ/wNh1Smvc9WnJA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@cacheable/memory": "^2.0.6",
-				"@cacheable/utils": "^2.3.2",
-				"hookified": "^1.14.0",
+				"@cacheable/memory": "^2.0.7",
+				"@cacheable/utils": "^2.3.3",
+				"hookified": "^1.15.0",
 				"keyv": "^5.5.5",
-				"qified": "^0.5.3"
+				"qified": "^0.6.0"
 			}
 		},
 		"node_modules/cacheable/node_modules/keyv": {
-			"version": "5.5.5",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.5.5.tgz",
-			"integrity": "sha512-FA5LmZVF1VziNc0bIdCSA1IoSVnDCqE8HJIZZv2/W8YmoAM50+tnUgJR/gQZwEeIMleuIOnRnHA/UaZRNeV4iQ==",
+			"version": "5.6.0",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+			"integrity": "sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -9729,6 +9766,17 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/colorjs.io": {
+			"version": "0.6.1",
+			"resolved": "https://registry.npmjs.org/colorjs.io/-/colorjs.io-0.6.1.tgz",
+			"integrity": "sha512-8lyR2wHzuIykCpqHKgluGsqQi5iDm3/a2IgP2GBZrasn2sBRkE4NOGsglZxWLs/jZQoNkmA/KM/8NV16rLUdBg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/color"
+			}
+		},
 		"node_modules/combined-stream": {
 			"version": "1.0.8",
 			"dev": true,
@@ -9946,9 +9994,9 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
-			"integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+			"version": "3.48.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.48.0.tgz",
+			"integrity": "sha512-zpEHTy1fjTMZCKLHUZoVeylt9XrzaIN2rbPXEt0k+q7JE5CkCZdo6bNq55bn24a69CH7ErAVLKijxJja4fw+UQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -11781,14 +11829,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "5.5.4",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
-			"integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
+			"version": "5.5.5",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
+			"integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"prettier-linter-helpers": "^1.0.0",
-				"synckit": "^0.11.7"
+				"prettier-linter-helpers": "^1.0.1",
+				"synckit": "^0.11.12"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -12109,9 +12157,9 @@
 			}
 		},
 		"node_modules/esquery": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
-			"integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+			"integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -13363,9 +13411,9 @@
 			}
 		},
 		"node_modules/hookified": {
-			"version": "1.14.0",
-			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.14.0.tgz",
-			"integrity": "sha512-pi1ynXIMFx/uIIwpWJ/5CEtOHLGtnUB0WhGeeYT+fKcQ+WCQbm3/rrkAXnpfph++PgepNqPdTC2WTj8A6k6zoQ==",
+			"version": "1.15.0",
+			"resolved": "https://registry.npmjs.org/hookified/-/hookified-1.15.0.tgz",
+			"integrity": "sha512-51w+ZZGt7Zw5q7rM3nC4t3aLn/xvKDETsXqMczndvwyVQhAHfUmUuFBRFcos8Iyebtk7OAE9dL26wFNzZVVOkw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16049,9 +16097,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/lighthouse/node_modules/@puppeteer/browsers": {
-			"version": "2.11.0",
-			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.0.tgz",
-			"integrity": "sha512-n6oQX6mYkG8TRPuPXmbPidkUbsSRalhmaaVAQxvH1IkQy63cwsH+kOjB3e4cpCDHg0aSvsiX9bQ4s2VB6mGWUQ==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.11.1.tgz",
+			"integrity": "sha512-YmhAxs7XPuxN0j7LJloHpfD1ylhDuFmmwMvfy/+6nBSrETT2ycL53LrhgPtR+f+GcPSybQVuQ5inWWu5MrWCpA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -16071,28 +16119,28 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.34.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.34.0.tgz",
-			"integrity": "sha512-24evawO+mUGW4mvS2a2ivwLdX3gk8zRLZr9HP+7+VT2vBQnm0oh9jJEZmUE3ePJhRkYlZ93i7OMpdcoi2qNCLg==",
+			"version": "24.36.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.36.0.tgz",
+			"integrity": "sha512-P3Ou0MAFDCQ0dK1d9F9+8jTrg6JvXjUacgG0YkJQP4kbEnUOGokSDEMmMId5ZhXD5HwsHM202E9VwEpEjWfwxg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@puppeteer/browsers": "2.11.0",
-				"chromium-bidi": "12.0.1",
+				"@puppeteer/browsers": "2.11.1",
+				"chromium-bidi": "13.0.1",
 				"debug": "^4.4.3",
-				"devtools-protocol": "0.0.1534754",
+				"devtools-protocol": "0.0.1551306",
 				"typed-query-selector": "^2.12.0",
-				"webdriver-bidi-protocol": "0.3.10",
-				"ws": "^8.18.3"
+				"webdriver-bidi-protocol": "0.4.0",
+				"ws": "^8.19.0"
 			},
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/chromium-bidi": {
-			"version": "12.0.1",
-			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-12.0.1.tgz",
-			"integrity": "sha512-fGg+6jr0xjQhzpy5N4ErZxQ4wF7KLEvhGZXD6EgvZKDhu7iOhZXnZhcDxPJDcwTcrD48NPzOCo84RP2lv3Z+Cg==",
+			"version": "13.0.1",
+			"resolved": "https://registry.npmjs.org/chromium-bidi/-/chromium-bidi-13.0.1.tgz",
+			"integrity": "sha512-c+RLxH0Vg2x2syS9wPw378oJgiJNXtYXUvnVAldUlt5uaHekn0CCU7gPksNgHjrH1qFhmjVXQj4esvuthuC7OQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -16104,16 +16152,16 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1534754",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1534754.tgz",
-			"integrity": "sha512-26T91cV5dbOYnXdJi5qQHoTtUoNEqwkHcAyu/IKtjIAxiEqPMrDiRkDOPWVsGfNZGmlQVHQbZRSjD8sxagWVsQ==",
+			"version": "0.0.1551306",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1551306.tgz",
+			"integrity": "sha512-CFx8QdSim8iIv+2ZcEOclBKTQY6BI1IEDa7Tm9YkwAXzEWFndTEzpTo5jAUhSnq24IC7xaDw0wvGcm96+Y3PEg==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.19.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+			"integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -16242,9 +16290,9 @@
 			"license": "MIT"
 		},
 		"node_modules/lodash-es": {
-			"version": "4.17.22",
-			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
-			"integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
+			"version": "4.17.23",
+			"resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+			"integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -17729,9 +17777,9 @@
 			}
 		},
 		"node_modules/pg-protocol": {
-			"version": "1.10.3",
-			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-			"integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.11.0.tgz",
+			"integrity": "sha512-pfsxk2M9M3BuGgDOfuy37VNRRX3jmKgMjcvAcWqNDpZSf4cUmv8HSOl5ViRQFsfARFn0KuUQTgLxVMbNq5NW3g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -17878,14 +17926,14 @@
 			}
 		},
 		"node_modules/playwright": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.57.0.tgz",
-			"integrity": "sha512-ilYQj1s8sr2ppEJ2YVadYBN0Mb3mdo9J0wQ+UuDhzYqURwSoW4n1Xs5vs7ORwgDGmyEh33tRMeS8KhdkMoLXQw==",
+			"version": "1.58.0",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
+			"integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
 			"dependencies": {
-				"playwright-core": "1.57.0"
+				"playwright-core": "1.58.0"
 			},
 			"bin": {
 				"playwright": "cli.js"
@@ -17898,9 +17946,9 @@
 			}
 		},
 		"node_modules/playwright-core": {
-			"version": "1.57.0",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.57.0.tgz",
-			"integrity": "sha512-agTcKlMw/mjBWOnD6kFZttAAGHgi/Nw0CZ2o6JqWSbMlI219lAFLZZCyqByTsvVAJq5XA5H8cA6PrvBRpBWEuQ==",
+			"version": "1.58.0",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
+			"integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -17909,6 +17957,22 @@
 			},
 			"engines": {
 				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/plur": {
@@ -18823,13 +18887,13 @@
 			"license": "MIT"
 		},
 		"node_modules/qified": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/qified/-/qified-0.5.3.tgz",
-			"integrity": "sha512-kXuQdQTB6oN3KhI6V4acnBSZx8D2I4xzZvn9+wFLLFCoBNQY/sFnCW6c43OL7pOQ2HvGV4lnWIXNmgfp7cTWhQ==",
+			"version": "0.6.0",
+			"resolved": "https://registry.npmjs.org/qified/-/qified-0.6.0.tgz",
+			"integrity": "sha512-tsSGN1x3h569ZSU1u6diwhltLyfUWDp3YbFHedapTmpBl0B3P6U3+Qptg7xu+v+1io1EwhdPyyRHYbEw0KN2FA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"hookified": "^1.13.0"
+				"hookified": "^1.14.0"
 			},
 			"engines": {
 				"node": ">=20"
@@ -20915,9 +20979,9 @@
 			}
 		},
 		"node_modules/stylelint-scss/node_modules/mdn-data": {
-			"version": "2.25.0",
-			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.25.0.tgz",
-			"integrity": "sha512-T2LPsjgUE/tgMmRXREVmwsux89DwWfNjiynOeXuLd2mX6jphGQ2YE3Ukz7LQ2VOFKiVZU/Ee1GqzHiipZCjymw==",
+			"version": "2.26.0",
+			"resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.26.0.tgz",
+			"integrity": "sha512-ZqI0qjKWHMPcGUfLmlr80NPNVHIOjPMHtIOe1qXYFGS0YBZ1YKAzo9yk8W+gGrLCN0Xdv/RKxqdIsqPakEfmow==",
 			"dev": true,
 			"license": "CC0-1.0"
 		},
@@ -21024,25 +21088,25 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/file-entry-cache": {
-			"version": "11.1.1",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.1.tgz",
-			"integrity": "sha512-TPVFSDE7q91Dlk1xpFLvFllf8r0HyOMOlnWy7Z2HBku5H3KhIeOGInexrIeg2D64DosVB/JXkrrk6N/7Wriq4A==",
+			"version": "11.1.2",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+			"integrity": "sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"flat-cache": "^6.1.19"
+				"flat-cache": "^6.1.20"
 			}
 		},
 		"node_modules/stylelint/node_modules/flat-cache": {
-			"version": "6.1.19",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.19.tgz",
-			"integrity": "sha512-l/K33newPTZMTGAnnzaiqSl6NnH7Namh8jBNjrgjprWxGmZUuxx/sJNIRaijOh3n7q7ESbhNZC+pvVZMFdeU4A==",
+			"version": "6.1.20",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.20.tgz",
+			"integrity": "sha512-AhHYqwvN62NVLp4lObVXGVluiABTHapoB57EyegZVmazN+hhGhLTn3uZbOofoTw4DSDvVCadzzyChXhOAvy8uQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cacheable": "^2.2.0",
+				"cacheable": "^2.3.2",
 				"flatted": "^3.3.3",
-				"hookified": "^1.13.0"
+				"hookified": "^1.15.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/global-modules": {
@@ -21291,9 +21355,9 @@
 			"license": "MIT"
 		},
 		"node_modules/synckit": {
-			"version": "0.11.11",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
-			"integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
+			"version": "0.11.12",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
+			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -22014,7 +22078,9 @@
 			}
 		},
 		"node_modules/undici-types": {
-			"version": "7.16.0",
+			"version": "6.21.0",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+			"integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -22384,19 +22450,19 @@
 			}
 		},
 		"node_modules/vitest": {
-			"version": "4.0.16",
-			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.16.tgz",
-			"integrity": "sha512-E4t7DJ9pESL6E3I8nFjPa4xGUd3PmiWDLsDztS2qXSJWfHtbQnwAWylaBvSNY48I3vr8PTqIZlyK8TE3V3CA4Q==",
+			"version": "4.0.18",
+			"resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+			"integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@vitest/expect": "4.0.16",
-				"@vitest/mocker": "4.0.16",
-				"@vitest/pretty-format": "4.0.16",
-				"@vitest/runner": "4.0.16",
-				"@vitest/snapshot": "4.0.16",
-				"@vitest/spy": "4.0.16",
-				"@vitest/utils": "4.0.16",
+				"@vitest/expect": "4.0.18",
+				"@vitest/mocker": "4.0.18",
+				"@vitest/pretty-format": "4.0.18",
+				"@vitest/runner": "4.0.18",
+				"@vitest/snapshot": "4.0.18",
+				"@vitest/spy": "4.0.18",
+				"@vitest/utils": "4.0.18",
 				"es-module-lexer": "^1.7.0",
 				"expect-type": "^1.2.2",
 				"magic-string": "^0.30.21",
@@ -22424,10 +22490,10 @@
 				"@edge-runtime/vm": "*",
 				"@opentelemetry/api": "^1.9.0",
 				"@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-				"@vitest/browser-playwright": "4.0.16",
-				"@vitest/browser-preview": "4.0.16",
-				"@vitest/browser-webdriverio": "4.0.16",
-				"@vitest/ui": "4.0.16",
+				"@vitest/browser-playwright": "4.0.18",
+				"@vitest/browser-preview": "4.0.18",
+				"@vitest/browser-webdriverio": "4.0.18",
+				"@vitest/ui": "4.0.18",
 				"happy-dom": "*",
 				"jsdom": "*"
 			},
@@ -22528,9 +22594,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/webdriver-bidi-protocol": {
-			"version": "0.3.10",
-			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.3.10.tgz",
-			"integrity": "sha512-5LAE43jAVLOhB/QqX4bwSiv0Hg1HBfMmOuwBSXHdvg4GMGu9Y0lIq7p4R/yySu6w74WmaR4GM4H9t2IwLW7hgw==",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/webdriver-bidi-protocol/-/webdriver-bidi-protocol-0.4.0.tgz",
+			"integrity": "sha512-U9VIlNRrq94d1xxR9JrCEAx5Gv/2W7ERSv8oWRoNe/QYbfccS0V3h/H6qeNeCRJxXGMhhnkqvwNrvPAYeuP9VA==",
 			"dev": true,
 			"license": "Apache-2.0"
 		},

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtual-media-folders",
-	"version": "1.6.6",
+	"version": "1.6.7",
 	"description": "Virtual folder organization and smart management for the WordPress Media Library.",
 	"scripts": {
 		"build": "wp-scripts build",
@@ -18,11 +18,11 @@
 		"@testing-library/react": "^14.0.0",
 		"@testing-library/user-event": "^14.6.1",
 		"@vitejs/plugin-react": "^5.1.2",
-		"@wordpress/scripts": "^31.2.0",
+		"@wordpress/scripts": "^31.3.0",
 		"jsdom": "^24.0.0",
 		"react": "^18.3.1",
 		"react-dom": "^18.3.1",
-		"vitest": "^4.0.16"
+		"vitest": "^4.0.18"
 	},
 	"dependencies": {
 		"@dnd-kit/core": "^6.3.1",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: media, ai, organization, media library, virtual folders
 Requires at least: 6.8
 Tested up to: 6.9
-Stable tag: 1.6.6
+Stable tag: 1.6.7
 Requires PHP: 8.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -118,6 +118,10 @@ Only the folder organization is removed. Your media files are not deleted.
 Virtual Media Folders works entirely within the WordPress admin. It doesn't affect your front-end theme.
 
 == Changelog ==
+
+= 1.6.7 =
+* Changed: Updated @wordpress/scripts to 31.3.0
+* Changed: Updated vitest to 4.0.18
 
 = 1.6.6 =
 * Added: New `vmfo_can_delete_folder` filter allows add-ons to prevent folder deletion

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'soderlind/virtual-media-folders',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '08217d34900707a1e15d7e5b4f1b4adfe84ac00f',
+        'reference' => 'a977c64398f7d27f765c7045103ca8c9519480aa',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'soderlind/virtual-media-folders' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '08217d34900707a1e15d7e5b4f1b4adfe84ac00f',
+            'reference' => 'a977c64398f7d27f765c7045103ca8c9519480aa',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/virtual-media-folders.php
+++ b/virtual-media-folders.php
@@ -14,7 +14,7 @@
  * @wordpress-plugin
  * Plugin Name: Virtual Media Folders
  * Description: Virtual folder organization and smart management for the WordPress Media Library.
- * Version: 1.6.6
+ * Version: 1.6.7
  * Requires at least: 6.8
  * Requires PHP: 8.3
  * Author: Per Soderlind


### PR DESCRIPTION
This pull request updates the project to version 1.6.7, focusing on upgrading key development dependencies for improved stability and compatibility. No functional or feature changes are included.

Dependency updates:

* Upgraded `@wordpress/scripts` from version 31.2.0 to 31.3.0 in `package.json`.
* Upgraded `vitest` from version 4.0.16 to 4.0.18 in `package.json`.

Version and documentation updates:

* Bumped the version number to 1.6.7 in `package.json`, `virtual-media-folders.php`, and `readme.txt`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-e59373c6735cd495bd143c9b95e1a2405e8d255e742486da10bc8633a2367473L17-R17) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)
* Added a new changelog entry for 1.6.7 in both `CHANGELOG.md` and `readme.txt`, documenting the dependency updates. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R122-R125)
* Updated changelog links in `CHANGELOG.md` to include the new 1.6.7 release.