### PR TITLE
remove Media Folders metabox from attachment edit screen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to Virtual Media Folders will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.6.8] - 2026-01-27
+
+### Fixed
+- Removed Media Folders metabox from attachment edit screen (folders are managed via the media library sidebar)
+
 ## [1.6.7] - 2026-01-23
 
 ### Changed
@@ -611,6 +616,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Requires PHP 7.4+
 - Uses React 18 for UI components
 - Leverages WordPress REST API for all operations
+[1.6.8]: https://github.com/soderlind/virtual-media-folders/compare/1.6.7...1.6.8
 [1.6.7]: https://github.com/soderlind/virtual-media-folders/compare/1.6.6...1.6.7
 [1.6.6]: https://github.com/soderlind/virtual-media-folders/compare/1.6.5...1.6.6
 [1.6.5]: https://github.com/soderlind/virtual-media-folders/compare/1.6.4...1.6.5

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: media, ai, organization, media library, folders
 Requires at least: 6.8
 Tested up to: 6.9
-Stable tag: 1.6.7
+Stable tag: 1.6.8
 Requires PHP: 8.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -120,6 +120,9 @@ Only the folder organization is removed. Your media files are not deleted.
 Virtual Media Folders works entirely within the WordPress admin. It doesn't affect your front-end theme.
 
 == Changelog ==
+
+= 1.6.8 =
+* Fixed: Removed Media Folders metabox from attachment edit screen (folders are managed via the media library sidebar)
 
 = 1.6.7 =
 * Changed: Updated @wordpress/scripts to 31.3.0

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -185,6 +185,9 @@ class Taxonomy {
 			'show_ui'               => $show_ui,
 			// Don't add a column to the media list table (we use our own sidebar).
 			'show_admin_column'     => false,
+			// Disable the default taxonomy metabox on attachment edit screen.
+			// The plugin provides its own folder management UI in the media library.
+			'meta_box_cb'           => false,
 			// Enable REST API for React-based UI components.
 			'show_in_rest'          => true,
 			'rest_base'             => 'vmfo-folders',

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'soderlind/virtual-media-folders',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'a977c64398f7d27f765c7045103ca8c9519480aa',
+        'reference' => '91e1f7c8ff6df968ab446784330ffe3de47bc36a',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'soderlind/virtual-media-folders' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'a977c64398f7d27f765c7045103ca8c9519480aa',
+            'reference' => '91e1f7c8ff6df968ab446784330ffe3de47bc36a',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/virtual-media-folders.php
+++ b/virtual-media-folders.php
@@ -14,7 +14,7 @@
  * @wordpress-plugin
  * Plugin Name: Virtual Media Folders
  * Description: Virtual folder organization and smart management for the WordPress Media Library.
- * Version: 1.6.7
+ * Version: 1.6.8
  * Requires at least: 6.8
  * Requires PHP: 8.3
  * Author: Per Soderlind


### PR DESCRIPTION
This pull request updates the Virtual Media Folders plugin to version 1.6.8, focusing on improving the user experience by removing the Media Folders metabox from the attachment edit screen. Folder management is now streamlined exclusively through the media library sidebar. The changelog and documentation have been updated to reflect this change.

**User Experience Improvements:**
* Removed the Media Folders metabox from the attachment edit screen by setting the `meta_box_cb` argument to `false` in the taxonomy registration. Folder management is now handled only via the media library sidebar.

**Documentation and Versioning:**
* Updated the plugin version to `1.6.8` in `virtual-media-folders.php` and `readme.txt`. [[1]](diffhunk://#diff-e59373c6735cd495bd143c9b95e1a2405e8d255e742486da10bc8633a2367473L17-R17) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)
* Added a changelog entry for version 1.6.8 in both `CHANGELOG.md` and `readme.txt`, describing the removal of the metabox. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R124-R126)
* Added a comparison link for version 1.6.8 in `CHANGELOG.md`.