### PR TITLE
feat: add AddonChecker class for managing add-on version checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Virtual Media Folders will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.7.2] - 2026-02-10
+
+### Added
+
+- Add-on version checker displays admin notices when installed add-ons need updates
+- New `AddonChecker` class monitors vmfa-ai-organizer, vmfa-rules-engine, vmfa-editorial-workflow, and vmfa-media-cleanup versions
+- Notices only appear on Media Library pages (upload.php, media-new.php)
+- PHPUnit tests for AddonChecker class
+
 ## [1.7.1] - 2026-02-09
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtual-media-folders",
-	"version": "1.7.1",
+	"version": "1.7.2",
 	"description": "Virtual folder organization and smart management for the WordPress Media Library.",
 	"scripts": {
 		"build": "wp-scripts build",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: media, ai, organization, media library, folders
 Requires at least: 6.8
 Tested up to: 6.9
-Stable tag: 1.7.1
+Stable tag: 1.7.2
 Requires PHP: 8.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -122,6 +122,13 @@ Only the folder organization is removed. Your media files are not deleted.
 Virtual Media Folders works entirely within the WordPress admin. It doesn't affect your front-end theme.
 
 == Changelog ==
+
+= 1.7.2 =
+* NOTE: The plugin updater for add-ons is still in early stages and may not be fully reliable. Pleas update add-ons manually from their GitHub repositories for now.
+* Added: Add-on version checker displays admin notices when installed add-ons need updates
+* Added: New AddonChecker class monitors vmfa-ai-organizer, vmfa-rules-engine, vmfa-editorial-workflow, and vmfa-media-cleanup versions
+* Added: Notices only appear on Media Library pages
+* Added: PHPUnit tests for AddonChecker class
 
 = 1.7.1 =
 * Fixed: Version constant now reflects actual plugin version (was hardcoded to 1.3.8)

--- a/src/AddonChecker.php
+++ b/src/AddonChecker.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Add-on version checker for Virtual Media Folders.
+ *
+ * Displays admin notices when installed add-ons have outdated versions.
+ *
+ * @package VirtualMediaFolders
+ * @since   1.8.0
+ */
+
+namespace VirtualMediaFolders;
+
+/**
+ * Checks add-on versions and displays update notices.
+ */
+class AddonChecker {
+
+	/**
+	 * Minimum required versions for add-ons.
+	 *
+	 * @var array<string, array{name: string, min_version: string}>
+	 */
+	private const ADDONS = [
+		'vmfa-ai-organizer/vmfa-ai-organizer.php'             => [
+			'name'        => 'AI Organizer',
+			'min_version' => '1.2.0',
+		],
+		'vmfa-rules-engine/vmfa-rules-engine.php'             => [
+			'name'        => 'Rules Engine',
+			'min_version' => '1.4.0',
+		],
+		'vmfa-editorial-workflow/vmfa-editorial-workflow.php' => [
+			'name'        => 'Editorial Workflow',
+			'min_version' => '1.6.0',
+		],
+		'vmfa-media-cleanup/vmfa-media-cleanup.php'           => [
+			'name'        => 'Media Cleanup',
+			'min_version' => '1.1.0',
+		],
+	];
+
+	/**
+	 * Initialize the add-on checker.
+	 *
+	 * @return void
+	 */
+	public static function init(): void {
+		add_action( 'admin_notices', [ self::class, 'check_addon_versions' ] );
+	}
+
+	/**
+	 * Check add-on versions and display notices for outdated ones.
+	 *
+	 * Only runs on Media Library pages (upload.php, media-new.php).
+	 *
+	 * @return void
+	 */
+	public static function check_addon_versions(): void {
+		global $pagenow;
+
+		// Only show on Media Library pages.
+		if ( ! in_array( $pagenow, [ 'upload.php', 'media-new.php' ], true ) ) {
+			return;
+		}
+
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		if ( ! function_exists( 'is_plugin_active' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		foreach ( self::ADDONS as $plugin_file => $addon ) {
+			if ( ! is_plugin_active( $plugin_file ) ) {
+				continue;
+			}
+
+			$plugin_path = WP_PLUGIN_DIR . '/' . $plugin_file;
+			if ( ! file_exists( $plugin_path ) ) {
+				continue;
+			}
+
+			$plugin_data     = get_plugin_data( $plugin_path );
+			$current_version = $plugin_data[ 'Version' ] ?? '0.0.0';
+
+			if ( version_compare( $current_version, $addon[ 'min_version' ], '<' ) ) {
+				self::render_notice( $addon[ 'name' ], $current_version, $addon[ 'min_version' ] );
+			}
+		}
+	}
+
+	/**
+	 * Render the update notice for an outdated add-on.
+	 *
+	 * @param string $name            The add-on display name.
+	 * @param string $current_version The currently installed version.
+	 * @param string $min_version     The minimum required version.
+	 * @return void
+	 */
+	private static function render_notice( string $name, string $current_version, string $min_version ): void {
+		printf(
+			'<div class="notice notice-info is-dismissible"><p>%s</p></div>',
+			sprintf(
+				/* translators: 1: Add-on name, 2: Current version, 3: Minimum required version 4: Link to GitHub repository */
+				esc_html__( 'A new version of Virtual Media Folders - %1$s is available. You have version %2$s. Please update to version %3$s or later. The new version is available via %4$s', 'virtual-media-folders' ),
+				esc_html( $name ),
+				esc_html( $current_version ),
+				esc_html( $min_version ),
+				sprintf( '<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>', esc_html( 'https://github.com/soderlind' ), esc_html( 'https://github.com/soderlind' ) )
+			)
+		);
+	}
+}

--- a/tests/php/AddonCheckerTest.php
+++ b/tests/php/AddonCheckerTest.php
@@ -1,0 +1,281 @@
+<?php
+/**
+ * AddonChecker class tests.
+ *
+ * @package VirtualMediaFolders
+ */
+
+declare(strict_types=1);
+
+namespace VirtualMediaFolders\Tests;
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use VirtualMediaFolders\AddonChecker;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests for AddonChecker class.
+ */
+class AddonCheckerTest extends TestCase {
+	/**
+	 * Set up before each test.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Test init registers the admin_notices action.
+	 */
+	public function test_init_registers_action(): void {
+		Functions\expect( 'add_action' )
+			->once()
+			->with( 'admin_notices', [ AddonChecker::class, 'check_addon_versions' ] );
+
+		AddonChecker::init();
+
+		$this->assertTrue( true ); // Expectation verified by Brain\Monkey
+	}
+
+	/**
+	 * Test check_addon_versions returns early for non-media pages.
+	 */
+	public function test_check_addon_versions_skips_non_media_pages(): void {
+		global $pagenow;
+		$pagenow = 'edit.php';
+
+		Functions\expect( 'is_plugin_active' )->never();
+		Functions\expect( 'get_plugin_data' )->never();
+
+		AddonChecker::check_addon_versions();
+
+		$this->assertTrue( true ); // Expectation verified by Brain\Monkey
+	}
+
+	/**
+	 * Test check_addon_versions runs on upload.php page.
+	 */
+	public function test_check_addon_versions_runs_on_upload_page(): void {
+		global $pagenow;
+		$pagenow = 'upload.php';
+
+		Functions\expect( 'is_plugin_active' )
+			->times( 4 ) // Called for each of the 4 add-ons
+			->andReturn( false );
+
+		AddonChecker::check_addon_versions();
+
+		$this->assertTrue( true ); // Expectation verified by Brain\Monkey
+	}
+
+	/**
+	 * Test check_addon_versions runs on media-new.php page.
+	 */
+	public function test_check_addon_versions_runs_on_media_new_page(): void {
+		global $pagenow;
+		$pagenow = 'media-new.php';
+
+		Functions\expect( 'is_plugin_active' )
+			->times( 4 ) // Called for each of the 4 add-ons
+			->andReturn( false );
+
+		AddonChecker::check_addon_versions();
+
+		$this->assertTrue( true ); // Expectation verified by Brain\Monkey
+	}
+
+	/**
+	 * Test check_addon_versions skips inactive plugins.
+	 */
+	public function test_check_addon_versions_skips_inactive_plugins(): void {
+		global $pagenow;
+		$pagenow = 'upload.php';
+
+		Functions\expect( 'is_plugin_active' )
+			->times( 4 )
+			->andReturn( false );
+
+		Functions\expect( 'get_plugin_data' )->never();
+
+		AddonChecker::check_addon_versions();
+
+		$this->assertTrue( true ); // Expectation verified by Brain\Monkey
+	}
+
+	/**
+	 * Test check_addon_versions shows notice for outdated add-on.
+	 */
+	public function test_check_addon_versions_shows_notice_for_outdated_addon(): void {
+		global $pagenow;
+		$pagenow = 'upload.php';
+
+		if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
+			define( 'WP_PLUGIN_DIR', '/tmp/wp-content/plugins' );
+		}
+
+		// Create a temporary plugin file for testing
+		$plugin_dir  = WP_PLUGIN_DIR . '/vmfa-ai-organizer';
+		$plugin_file = $plugin_dir . '/vmfa-ai-organizer.php';
+
+		if ( ! is_dir( $plugin_dir ) ) {
+			mkdir( $plugin_dir, 0777, true );
+		}
+
+		file_put_contents( $plugin_file, "<?php\n/**\n * Plugin Name: AI Organizer\n * Version: 1.0.0\n */\n" );
+
+		Functions\expect( 'is_plugin_active' )
+			->with( 'vmfa-ai-organizer/vmfa-ai-organizer.php' )
+			->andReturn( true );
+
+		Functions\expect( 'is_plugin_active' )
+			->with( 'vmfa-rules-engine/vmfa-rules-engine.php' )
+			->andReturn( false );
+
+		Functions\expect( 'is_plugin_active' )
+			->with( 'vmfa-editorial-workflow/vmfa-editorial-workflow.php' )
+			->andReturn( false );
+
+		Functions\expect( 'is_plugin_active' )
+			->with( 'vmfa-media-cleanup/vmfa-media-cleanup.php' )
+			->andReturn( false );
+
+		Functions\expect( 'get_plugin_data' )
+			->once()
+			->with( $plugin_file )
+			->andReturn( [ 'Version' => '1.0.0' ] );
+
+		Functions\expect( 'esc_html__' )
+			->andReturnFirstArg();
+
+		Functions\expect( 'esc_html' )
+			->andReturnFirstArg();
+
+		$this->expectOutputRegex( '/notice notice-info is-dismissible/' );
+
+		AddonChecker::check_addon_versions();
+
+		// Cleanup
+		unlink( $plugin_file );
+		rmdir( $plugin_dir );
+	}
+
+	/**
+	 * Test check_addon_versions does not show notice when version is current.
+	 */
+	public function test_check_addon_versions_no_notice_when_version_current(): void {
+		global $pagenow;
+		$pagenow = 'upload.php';
+
+		if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
+			define( 'WP_PLUGIN_DIR', '/tmp/wp-content/plugins' );
+		}
+
+		// Create a temporary plugin file for testing
+		$plugin_dir  = WP_PLUGIN_DIR . '/vmfa-ai-organizer';
+		$plugin_file = $plugin_dir . '/vmfa-ai-organizer.php';
+
+		if ( ! is_dir( $plugin_dir ) ) {
+			mkdir( $plugin_dir, 0777, true );
+		}
+
+		file_put_contents( $plugin_file, "<?php\n/**\n * Plugin Name: AI Organizer\n * Version: 1.2.0\n */\n" );
+
+		Functions\expect( 'is_plugin_active' )
+			->with( 'vmfa-ai-organizer/vmfa-ai-organizer.php' )
+			->andReturn( true );
+
+		Functions\expect( 'is_plugin_active' )
+			->with( 'vmfa-rules-engine/vmfa-rules-engine.php' )
+			->andReturn( false );
+
+		Functions\expect( 'is_plugin_active' )
+			->with( 'vmfa-editorial-workflow/vmfa-editorial-workflow.php' )
+			->andReturn( false );
+
+		Functions\expect( 'is_plugin_active' )
+			->with( 'vmfa-media-cleanup/vmfa-media-cleanup.php' )
+			->andReturn( false );
+
+		Functions\expect( 'get_plugin_data' )
+			->once()
+			->with( $plugin_file )
+			->andReturn( [ 'Version' => '1.2.0' ] );
+
+		// esc_html__ and esc_html should NOT be called since no notice is rendered
+		Functions\expect( 'esc_html__' )->never();
+		Functions\expect( 'esc_html' )->never();
+
+		AddonChecker::check_addon_versions();
+
+		$this->assertTrue( true ); // Expectation verified by Brain\Monkey
+
+		// Cleanup
+		unlink( $plugin_file );
+		rmdir( $plugin_dir );
+	}
+
+	/**
+	 * Test check_addon_versions does not show notice when version is higher.
+	 */
+	public function test_check_addon_versions_no_notice_when_version_higher(): void {
+		global $pagenow;
+		$pagenow = 'upload.php';
+
+		if ( ! defined( 'WP_PLUGIN_DIR' ) ) {
+			define( 'WP_PLUGIN_DIR', '/tmp/wp-content/plugins' );
+		}
+
+		// Create a temporary plugin file for testing
+		$plugin_dir  = WP_PLUGIN_DIR . '/vmfa-ai-organizer';
+		$plugin_file = $plugin_dir . '/vmfa-ai-organizer.php';
+
+		if ( ! is_dir( $plugin_dir ) ) {
+			mkdir( $plugin_dir, 0777, true );
+		}
+
+		file_put_contents( $plugin_file, "<?php\n/**\n * Plugin Name: AI Organizer\n * Version: 2.0.0\n */\n" );
+
+		Functions\expect( 'is_plugin_active' )
+			->with( 'vmfa-ai-organizer/vmfa-ai-organizer.php' )
+			->andReturn( true );
+
+		Functions\expect( 'is_plugin_active' )
+			->with( 'vmfa-rules-engine/vmfa-rules-engine.php' )
+			->andReturn( false );
+
+		Functions\expect( 'is_plugin_active' )
+			->with( 'vmfa-editorial-workflow/vmfa-editorial-workflow.php' )
+			->andReturn( false );
+
+		Functions\expect( 'is_plugin_active' )
+			->with( 'vmfa-media-cleanup/vmfa-media-cleanup.php' )
+			->andReturn( false );
+
+		Functions\expect( 'get_plugin_data' )
+			->once()
+			->with( $plugin_file )
+			->andReturn( [ 'Version' => '2.0.0' ] );
+
+		// esc_html__ and esc_html should NOT be called since no notice is rendered
+		Functions\expect( 'esc_html__' )->never();
+		Functions\expect( 'esc_html' )->never();
+
+		AddonChecker::check_addon_versions();
+
+		$this->assertTrue( true ); // Expectation verified by Brain\Monkey
+
+		// Cleanup
+		unlink( $plugin_file );
+		rmdir( $plugin_dir );
+	}
+}

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -7,6 +7,7 @@ $baseDir = dirname($vendorDir);
 
 return array(
     'Composer\\InstalledVersions' => $vendorDir . '/composer/InstalledVersions.php',
+    'VirtualMediaFolders\\AddonChecker' => $baseDir . '/src/AddonChecker.php',
     'VirtualMediaFolders\\Admin' => $baseDir . '/src/Admin.php',
     'VirtualMediaFolders\\Editor' => $baseDir . '/src/Editor.php',
     'VirtualMediaFolders\\RestApi' => $baseDir . '/src/RestApi.php',

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -22,6 +22,7 @@ class ComposerStaticInit9da11f50a84c12ea0f2b8e42c40880be
 
     public static $classMap = array (
         'Composer\\InstalledVersions' => __DIR__ . '/..' . '/composer/InstalledVersions.php',
+        'VirtualMediaFolders\\AddonChecker' => __DIR__ . '/../..' . '/src/AddonChecker.php',
         'VirtualMediaFolders\\Admin' => __DIR__ . '/../..' . '/src/Admin.php',
         'VirtualMediaFolders\\Editor' => __DIR__ . '/../..' . '/src/Editor.php',
         'VirtualMediaFolders\\RestApi' => __DIR__ . '/../..' . '/src/RestApi.php',

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'soderlind/virtual-media-folders',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '91e1f7c8ff6df968ab446784330ffe3de47bc36a',
+        'reference' => '6d2c539d91822c876f59a06b40030037806a93a6',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'soderlind/virtual-media-folders' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '91e1f7c8ff6df968ab446784330ffe3de47bc36a',
+            'reference' => '6d2c539d91822c876f59a06b40030037806a93a6',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/virtual-media-folders.php
+++ b/virtual-media-folders.php
@@ -14,7 +14,7 @@
  * @wordpress-plugin
  * Plugin Name: Virtual Media Folders
  * Description: Virtual folder organization and smart management for the WordPress Media Library.
- * Version: 1.7.1
+ * Version: 1.7.2
  * Requires at least: 6.8
  * Requires PHP: 8.3
  * Author: Per Soderlind
@@ -55,7 +55,7 @@ if ( version_compare( get_bloginfo( 'version' ), '6.8', '<' ) ) {
 /*
  * Define plugin constants.
  */
-define( 'VMFO_VERSION', '1.7.1' );
+define( 'VMFO_VERSION', '1.7.2' );
 define( 'VMFO_FILE', __FILE__ );
 define( 'VMFO_PATH', __DIR__ . '/' );
 define( 'VMFO_URL', plugin_dir_url( __FILE__ ) );
@@ -157,5 +157,9 @@ add_action( 'plugins_loaded', static function () {
 
 	if ( class_exists( 'VirtualMediaFolders\\Settings' ) ) {
 		\VirtualMediaFolders\Settings::init();
+	}
+
+	if ( class_exists( 'VirtualMediaFolders\\AddonChecker' ) ) {
+		\VirtualMediaFolders\AddonChecker::init();
 	}
 } );


### PR DESCRIPTION

This pull request introduces a new add-on version checker feature for Virtual Media Folders, which displays admin notices when installed add-ons are outdated. The version checker is implemented via a new `AddonChecker` class, and is only active on Media Library pages. Comprehensive PHPUnit tests are included to verify its functionality. The plugin version is updated to 1.7.2 and documentation is updated accordingly.

**Add-on version checker feature:**

* Introduced the `AddonChecker` class in `src/AddonChecker.php` to monitor installed add-ons (`vmfa-ai-organizer`, `vmfa-rules-engine`, `vmfa-editorial-workflow`, `vmfa-media-cleanup`) and display admin notices if their versions are below the required minimum. Notices are shown only on Media Library pages (`upload.php`, `media-new.php`). [[1]](diffhunk://#diff-619756f329d0c42031e70d3a74083d6b0c0538b35ff0258a55e2da8edb854735R1-R114) [[2]](diffhunk://#diff-e59373c6735cd495bd143c9b95e1a2405e8d255e742486da10bc8633a2367473R161-R164)
* Registered the `AddonChecker` initialization in the main plugin file to activate the version checking logic.

**Testing:**

* Added PHPUnit tests for the `AddonChecker` class in `tests/php/AddonCheckerTest.php`, covering scenarios such as inactive plugins, outdated versions, and correct notice rendering.

**Documentation and version updates:**

* Updated plugin version to 1.7.2 in `package.json`, `readme.txt`, and `virtual-media-folders.php`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[3]](diffhunk://#diff-e59373c6735cd495bd143c9b95e1a2405e8d255e742486da10bc8633a2367473L17-R17) [[4]](diffhunk://#diff-e59373c6735cd495bd143c9b95e1a2405e8d255e742486da10bc8633a2367473L58-R58)
* Added changelog and readme entries describing the new add-on version checker feature and its limitations. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R16) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R126-R132)