### PR TITLE
Feature/vmfo upload folder hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Virtual Media Folders will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.8.1] - 2026-02-24
+
+### Added
+
+- `vmfo_upload_folder` filter for controlling folder assignment on upload (3 args: folder_id, attachment_id, metadata)
+- Moved `assign_default_folder` from `add_attachment` action to `wp_generate_attachment_metadata` filter so attachment metadata is available to callbacks
+- Returning 0 from the filter skips folder assignment; add-ons can override the default folder
+
 ## [1.8.0] - 2026-02-24
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtual-media-folders",
-	"version": "1.8.0",
+	"version": "1.8.1",
 	"description": "Virtual folder organization and smart management for the WordPress Media Library.",
 	"scripts": {
 		"build": "wp-scripts build",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: media, ai, organization, media library, folders
 Requires at least: 6.8
 Tested up to: 6.9
-Stable tag: 1.8.0
+Stable tag: 1.8.1
 Requires PHP: 8.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -129,6 +129,11 @@ Only the folder organization is removed. Your media files are not deleted.
 Virtual Media Folders works entirely within the WordPress admin. It doesn't affect your front-end theme.
 
 == Changelog ==
+
+= 1.8.1 =
+* Added: `vmfo_upload_folder` filter for controlling folder assignment on upload
+* Added: Attachment metadata now available to upload-folder filter callbacks
+* Added: Add-ons can override the default folder by hooking `vmfo_upload_folder`
 
 = 1.8.0 =
 * Changed: Sidebar preference stored server-side in user meta instead of localStorage

--- a/src/Admin.php
+++ b/src/Admin.php
@@ -37,7 +37,7 @@ class Admin {
 		add_action( 'admin_enqueue_scripts', [ static::class, 'enqueue_scripts' ] );
 		add_action( 'wp_ajax_vmfo_move_to_folder', [ static::class, 'ajax_move_to_folder' ] );
 		add_action( 'wp_ajax_vmfo_bulk_move_to_folder', [ static::class, 'ajax_bulk_move_to_folder' ] );
-		add_action( 'add_attachment', [ static::class, 'assign_default_folder' ] );
+		add_filter( 'wp_generate_attachment_metadata', [ static::class, 'assign_default_folder' ], 10, 3 );
 		add_action( 'admin_head-upload.php', [ static::class, 'add_help_tab' ] );
 		add_action( 'admin_enqueue_scripts', [ static::class, 'add_critical_css' ] );
 		add_action( 'admin_footer-upload.php', [ static::class, 'render_folder_button_script' ] );
@@ -189,21 +189,59 @@ class Admin {
 	}
 
 	/**
-	 * Assign new uploads to the default folder if configured.
+	 * Assign new uploads to a folder.
 	 *
-	 * @param int $attachment_id The newly uploaded attachment ID.
-	 * @return void
+	 * Hooked to 'wp_generate_attachment_metadata' so that attachment metadata
+	 * (dimensions, EXIF, etc.) is available to filter callbacks.
+	 *
+	 * The folder is determined by:
+	 * 1. The 'vmfo_upload_folder' filter (add-ons / custom code can override)
+	 * 2. The "Default folder for uploads" setting as fallback
+	 *
+	 * Returning 0 or false from the filter skips folder assignment.
+	 *
+	 * @since 1.8.1
+	 *
+	 * @param array  $metadata      Attachment metadata.
+	 * @param int    $attachment_id The attachment post ID.
+	 * @param string $context       Context: 'create' for new uploads.
+	 * @return array Unmodified metadata (this is a filter).
 	 */
-	public static function assign_default_folder( int $attachment_id ): void {
-		$default_folder = Settings::get( 'default_folder', 0 );
-
-		if ( $default_folder > 0 ) {
-			// Verify the folder exists
-			$term = get_term( $default_folder, Taxonomy::TAXONOMY );
-			if ( $term && ! is_wp_error( $term ) ) {
-				wp_set_object_terms( $attachment_id, [ $default_folder ], Taxonomy::TAXONOMY );
-			}
+	public static function assign_default_folder( array $metadata, int $attachment_id, string $context ): array {
+		// Only process new uploads.
+		if ( 'create' !== $context ) {
+			return $metadata;
 		}
+
+		$default_folder = (int) Settings::get( 'default_folder', 0 );
+
+		/**
+		 * Filter the folder term ID to assign to a newly uploaded attachment.
+		 *
+		 * Returning 0 or false skips folder assignment.
+		 * Returning an int assigns that folder term ID.
+		 *
+		 * @since 1.8.1
+		 *
+		 * @param int   $folder_id     The folder term ID (from settings, or 0).
+		 * @param int   $attachment_id The attachment post ID.
+		 * @param array $metadata      Attachment metadata (dimensions, EXIF, etc.).
+		 */
+		$folder_id = (int) apply_filters( 'vmfo_upload_folder', $default_folder, $attachment_id, $metadata );
+
+		if ( $folder_id <= 0 ) {
+			return $metadata;
+		}
+
+		// Verify the folder exists.
+		$term = get_term( $folder_id, Taxonomy::TAXONOMY );
+		if ( ! $term || is_wp_error( $term ) ) {
+			return $metadata;
+		}
+
+		wp_set_object_terms( $attachment_id, [ $folder_id ], Taxonomy::TAXONOMY );
+
+		return $metadata;
 	}
 
 	/**

--- a/tests/php/AdminTest.php
+++ b/tests/php/AdminTest.php
@@ -11,6 +11,7 @@ namespace VirtualMediaFolders\Tests;
 
 use Brain\Monkey;
 use Brain\Monkey\Functions;
+use Brain\Monkey\Filters;
 use VirtualMediaFolders\Admin;
 use PHPUnit\Framework\TestCase;
 
@@ -35,16 +36,17 @@ class AdminTest extends TestCase {
 	}
 
 	/**
-	 * Test init registers the enqueue_scripts action.
+	 * Test init registers hooks including wp_generate_attachment_metadata filter.
 	 */
 	public function test_init_registers_action(): void {
-		Functions\expect( 'add_action' )
-			->once()
-			->with( 'admin_enqueue_scripts', [ Admin::class, 'enqueue_scripts' ] );
-
 		Admin::init();
 
-		$this->assertTrue( true ); // Expectation verified by Brain\Monkey
+		$this->assertTrue(
+			has_action( 'admin_enqueue_scripts', [ Admin::class, 'enqueue_scripts' ] ) !== false
+		);
+		$this->assertTrue(
+			has_filter( 'wp_generate_attachment_metadata', [ Admin::class, 'assign_default_folder' ] ) !== false
+		);
 	}
 
 	/**
@@ -73,5 +75,106 @@ class AdminTest extends TestCase {
 		Admin::enqueue_scripts( 'upload.php' );
 
 		$this->assertTrue( true ); // Expectation verified by Brain\Monkey
+	}
+
+	/**
+	 * Test assign_default_folder skips non-create context.
+	 */
+	public function test_assign_default_folder_skips_non_create(): void {
+		Functions\expect( 'apply_filters' )->never();
+
+		$metadata = [ 'width' => 1920, 'height' => 1080 ];
+		$result   = Admin::assign_default_folder( $metadata, 123, 'update' );
+
+		$this->assertSame( $metadata, $result );
+	}
+
+	/**
+	 * Test assign_default_folder applies vmfo_upload_folder filter.
+	 */
+	public function test_assign_default_folder_applies_filter(): void {
+		// Mock get_option so Settings::get( 'default_folder' ) returns 5.
+		Functions\when( 'get_option' )->justReturn(
+			[ 'default_folder' => 5, 'show_all_media' => true, 'show_uncategorized' => true ]
+		);
+
+		Filters\expectApplied( 'vmfo_upload_folder' )
+			->once()
+			->with( 5, 123, [ 'width' => 1920 ] )
+			->andReturn( 5 );
+
+		Functions\expect( 'get_term' )
+			->once()
+			->with( 5, 'vmfo_folder' )
+			->andReturn( (object) [ 'term_id' => 5 ] );
+
+		Functions\expect( 'is_wp_error' )
+			->once()
+			->andReturn( false );
+
+		Functions\expect( 'wp_set_object_terms' )
+			->once()
+			->with( 123, [ 5 ], 'vmfo_folder' );
+
+		$metadata = [ 'width' => 1920 ];
+		$result   = Admin::assign_default_folder( $metadata, 123, 'create' );
+
+		$this->assertSame( $metadata, $result );
+	}
+
+	/**
+	 * Test assign_default_folder skips when filter returns 0.
+	 */
+	public function test_assign_default_folder_skips_when_filter_returns_zero(): void {
+		// Mock get_option so Settings::get( 'default_folder' ) returns 0.
+		Functions\when( 'get_option' )->justReturn(
+			[ 'default_folder' => 0, 'show_all_media' => true, 'show_uncategorized' => true ]
+		);
+
+		Filters\expectApplied( 'vmfo_upload_folder' )
+			->once()
+			->andReturn( 0 );
+
+		Functions\expect( 'get_term' )->never();
+		Functions\expect( 'wp_set_object_terms' )->never();
+
+		$metadata = [ 'width' => 1920 ];
+		$result   = Admin::assign_default_folder( $metadata, 123, 'create' );
+
+		$this->assertSame( $metadata, $result );
+	}
+
+	/**
+	 * Test assign_default_folder allows add-ons to override folder.
+	 */
+	public function test_assign_default_folder_addon_override(): void {
+		// Mock get_option so Settings::get( 'default_folder' ) returns 5.
+		Functions\when( 'get_option' )->justReturn(
+			[ 'default_folder' => 5, 'show_all_media' => true, 'show_uncategorized' => true ]
+		);
+
+		// Simulate an add-on overriding the folder to 42.
+		Filters\expectApplied( 'vmfo_upload_folder' )
+			->once()
+			->with( 5, 123, [ 'width' => 800 ] )
+			->andReturn( 42 );
+
+		Functions\expect( 'get_term' )
+			->once()
+			->with( 42, 'vmfo_folder' )
+			->andReturn( (object) [ 'term_id' => 42 ] );
+
+		Functions\expect( 'is_wp_error' )
+			->once()
+			->andReturn( false );
+
+		Functions\expect( 'wp_set_object_terms' )
+			->once()
+			->with( 123, [ 42 ], 'vmfo_folder' );
+
+		$metadata = [ 'width' => 800 ];
+		$result   = Admin::assign_default_folder( $metadata, 123, 'create' );
+
+		$this->assertSame( $metadata, $result );
 	}
 }

--- a/vendor/autoload.php
+++ b/vendor/autoload.php
@@ -14,7 +14,10 @@ if (PHP_VERSION_ID < 50600) {
             echo $err;
         }
     }
-    throw new RuntimeException($err);
+    trigger_error(
+        $err,
+        E_USER_ERROR
+    );
 }
 
 require_once __DIR__ . '/composer/autoload_real.php';

--- a/vendor/composer/InstalledVersions.php
+++ b/vendor/composer/InstalledVersions.php
@@ -27,12 +27,6 @@ use Composer\Semver\VersionParser;
 class InstalledVersions
 {
     /**
-     * @var string|null if set (by reflection by Composer), this should be set to the path where this class is being copied to
-     * @internal
-     */
-    private static $selfDir = null;
-
-    /**
      * @var mixed[]|null
      * @psalm-var array{root: array{name: string, pretty_version: string, version: string, reference: string|null, type: string, install_path: string, aliases: string[], dev: bool}, versions: array<string, array{pretty_version?: string, version?: string, reference?: string|null, type?: string, install_path?: string, aliases?: string[], dev_requirement: bool, replaced?: string[], provided?: string[]}>}|array{}|null
      */
@@ -329,18 +323,6 @@ class InstalledVersions
     }
 
     /**
-     * @return string
-     */
-    private static function getSelfDir()
-    {
-        if (self::$selfDir === null) {
-            self::$selfDir = strtr(__DIR__, '\\', '/');
-        }
-
-        return self::$selfDir;
-    }
-
-    /**
      * @return array[]
      * @psalm-return list<array{root: array{name: string, pretty_version: string, version: string, reference: string|null, type: string, install_path: string, aliases: string[], dev: bool}, versions: array<string, array{pretty_version?: string, version?: string, reference?: string|null, type?: string, install_path?: string, aliases?: string[], dev_requirement: bool, replaced?: string[], provided?: string[]}>}>
      */
@@ -354,7 +336,7 @@ class InstalledVersions
         $copiedLocalDir = false;
 
         if (self::$canGetVendors) {
-            $selfDir = self::getSelfDir();
+            $selfDir = strtr(__DIR__, '\\', '/');
             foreach (ClassLoader::getRegisteredLoaders() as $vendorDir => $loader) {
                 $vendorDir = strtr($vendorDir, '\\', '/');
                 if (isset(self::$installedByVendor[$vendorDir])) {

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -7,14 +7,14 @@ namespace Composer\Autoload;
 class ComposerStaticInit9da11f50a84c12ea0f2b8e42c40880be
 {
     public static $prefixLengthsPsr4 = array (
-        'V' =>
+        'V' => 
         array (
             'VirtualMediaFolders\\' => 20,
         ),
     );
 
     public static $prefixDirsPsr4 = array (
-        'VirtualMediaFolders\\' =>
+        'VirtualMediaFolders\\' => 
         array (
             0 => __DIR__ . '/../..' . '/src',
         ),

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'soderlind/virtual-media-folders',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'adfe74d2a935bd5ec159d98934963a5d7529d8fe',
+        'reference' => '9ca13b38dcbceae67a067cfd4f9ac3ea66569e5a',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'soderlind/virtual-media-folders' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'adfe74d2a935bd5ec159d98934963a5d7529d8fe',
+            'reference' => '9ca13b38dcbceae67a067cfd4f9ac3ea66569e5a',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/vendor/composer/installed.php
+++ b/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'soderlind/virtual-media-folders',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '9ca13b38dcbceae67a067cfd4f9ac3ea66569e5a',
+        'reference' => 'e40a6cf8998cda8449db7589fa16769da50f1dd5',
         'type' => 'wordpress-plugin',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -13,7 +13,7 @@
         'soderlind/virtual-media-folders' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '9ca13b38dcbceae67a067cfd4f9ac3ea66569e5a',
+            'reference' => 'e40a6cf8998cda8449db7589fa16769da50f1dd5',
             'type' => 'wordpress-plugin',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),

--- a/vendor/composer/platform_check.php
+++ b/vendor/composer/platform_check.php
@@ -19,7 +19,8 @@ if ($issues) {
             echo 'Composer detected issues in your platform:' . PHP_EOL.PHP_EOL . str_replace('You are running '.PHP_VERSION.'.', '', implode(PHP_EOL, $issues)) . PHP_EOL.PHP_EOL;
         }
     }
-    throw new \RuntimeException(
-        'Composer detected issues in your platform: ' . implode(' ', $issues)
+    trigger_error(
+        'Composer detected issues in your platform: ' . implode(' ', $issues),
+        E_USER_ERROR
     );
 }

--- a/virtual-media-folders.php
+++ b/virtual-media-folders.php
@@ -14,7 +14,7 @@
  * @wordpress-plugin
  * Plugin Name: Virtual Media Folders
  * Description: Virtual folder organization and smart management for the WordPress Media Library.
- * Version: 1.8.0
+ * Version: 1.8.1
  * Requires at least: 6.8
  * Requires PHP: 8.3
  * Author: Per Soderlind


### PR DESCRIPTION
This pull request introduces a new filter to control folder assignment for media uploads, moves the folder assignment logic to a later hook to provide access to attachment metadata, and allows add-ons to override the default folder assignment. The update is thoroughly documented and covered by new tests.

**Folder assignment improvements:**

* Added the `vmfo_upload_folder` filter, allowing custom code or add-ons to control which folder a new upload is assigned to. The filter receives the folder ID, attachment ID, and metadata, and returning 0 skips assignment.
* Moved the folder assignment logic from the `add_attachment` action to the `wp_generate_attachment_metadata` filter so that attachment metadata is available to filter callbacks. [[1]](diffhunk://#diff-dd7574c63cefd65c36ce6bf3cbd5f6e0a5ac664696e1b8546dad8994faff407bL40-R40) [[2]](diffhunk://#diff-dd7574c63cefd65c36ce6bf3cbd5f6e0a5ac664696e1b8546dad8994faff407bL192-R244)
* Add-ons can now override the default folder assignment by hooking the new filter.

**Testing and documentation:**

* Added comprehensive tests for the new folder assignment logic, including skipping assignment, applying the filter, and add-on overrides.
* Updated changelog, readme, and version numbers to reflect the changes and new features. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R15) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R133-R137) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[5]](diffhunk://#diff-e59373c6735cd495bd143c9b95e1a2405e8d255e742486da10bc8633a2367473L17-R17)