### PR TITLE
Release 2.0.2: parser-compatible ability validators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Virtual Media Folders will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2026-03-23
+
+### Fixed
+
+- Updated ability validator return type hints to `bool|WP_Error` for broader parser compatibility in release/pre-commit environments
+
 ## [2.0.1] - 2026-03-23
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtual-media-folders",
-	"version": "2.0.1",
+	"version": "2.0.2",
 	"description": "Virtual folder organization and smart management for the WordPress Media Library.",
 	"scripts": {
 		"build": "wp-scripts build",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: media, ai, organization, media library, folders
 Requires at least: 6.8
 Tested up to: 7.0
-Stable tag: 2.0.1
+Stable tag: 2.0.2
 Requires PHP: 8.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -172,6 +172,9 @@ Only the folder organization is removed. Your media files are not deleted.
 Virtual Media Folders works entirely within the WordPress admin. It doesn't affect your front-end theme.
 
 == Changelog ==
+
+= 2.0.2 =
+* Fixed: Updated ability validator return type hints to `bool|WP_Error` for broader parser compatibility in release/pre-commit environments
 
 = 2.0.1 =
 * Added: Abilities API integration with `vmfo/list-folders` and `vmfo/add-to-folder`

--- a/src/AbilitiesIntegration.php
+++ b/src/AbilitiesIntegration.php
@@ -413,9 +413,9 @@ final class AbilitiesIntegration {
 	 * Validate the target folder.
 	 *
 	 * @param int $folder_id Folder term ID.
-	 * @return true|WP_Error
+	 * @return bool|WP_Error
 	 */
-	private static function validate_folder( int $folder_id ): true|WP_Error {
+	private static function validate_folder( int $folder_id ): bool|WP_Error {
 		$folder = get_term( $folder_id, Taxonomy::TAXONOMY );
 
 		if ( is_wp_error( $folder ) ) {
@@ -437,9 +437,9 @@ final class AbilitiesIntegration {
 	 * Validate attachments before mutation.
 	 *
 	 * @param array<int, int> $attachment_ids Attachment IDs.
-	 * @return true|WP_Error
+	 * @return bool|WP_Error
 	 */
-	private static function validate_attachments( array $attachment_ids ): true|WP_Error {
+	private static function validate_attachments( array $attachment_ids ): bool|WP_Error {
 		foreach ( $attachment_ids as $attachment_id ) {
 			$attachment = get_post( $attachment_id );
 

--- a/virtual-media-folders.php
+++ b/virtual-media-folders.php
@@ -14,7 +14,7 @@
  * @wordpress-plugin
  * Plugin Name: Virtual Media Folders
  * Description: Virtual folder organization and smart management for the WordPress Media Library.
- * Version: 2.0.1
+ * Version: 2.0.2
  * Requires at least: 6.8
  * Requires PHP: 8.3
  * Author: Per Soderlind
@@ -55,7 +55,7 @@ if ( version_compare( get_bloginfo( 'version' ), '6.8', '<' ) ) {
 /*
  * Define plugin constants.
  */
-define( 'VMFO_VERSION', '2.0.1' );
+define( 'VMFO_VERSION', '2.0.2' );
 define( 'VMFO_FILE', __FILE__ );
 define( 'VMFO_PATH', __DIR__ . '/' );
 define( 'VMFO_URL', plugin_dir_url( __FILE__ ) );


### PR DESCRIPTION
This pull request releases version 2.0.2 of Virtual Media Folders, focusing on improving compatibility by updating type hints in ability validator methods. The update ensures that the return types align with broader parser requirements in release and pre-commit environments. Documentation and metadata have also been updated to reflect the new version.

**Compatibility Improvements:**

* Changed the return type hints of `validate_folder` and `validate_attachments` in `AbilitiesIntegration.php` from `true|WP_Error` to `bool|WP_Error` for better compatibility with various PHP parsers. [[1]](diffhunk://#diff-46c2bb02d336c6753cb00440195f9a958f721c4d9c4748f7baab66695d0a05fcL416-R418) [[2]](diffhunk://#diff-46c2bb02d336c6753cb00440195f9a958f721c4d9c4748f7baab66695d0a05fcL440-R442)

**Documentation and Metadata Updates:**

* Updated the version to 2.0.2 in `package.json`, `readme.txt`, and `virtual-media-folders.php`, and changed the `VMFO_VERSION` constant accordingly. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[3]](diffhunk://#diff-e59373c6735cd495bd143c9b95e1a2405e8d255e742486da10bc8633a2367473L17-R17) [[4]](diffhunk://#diff-e59373c6735cd495bd143c9b95e1a2405e8d255e742486da10bc8633a2367473L58-R58)
* Added a changelog entry in both `CHANGELOG.md` and `readme.txt` describing the type hint fix for this release. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R13) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R176-R178)