### PR TITLE
Expand MCP/AI integration 

### DIFF
--- a/.github/skills/add-photo-to-folder/SKILL.md
+++ b/.github/skills/add-photo-to-folder/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: add-photo-to-folder
+description: "Use when uploading or organizing images in Virtual Media Folders using MCP. Triggers: add photo to folder, place image by content, classify image into folder, auto-folder image. Uses vmfo/list-folders, vmfo/create-folder, and vmfo/add-to-folder through mcp-adapter-execute-ability."
+---
+
+# Add Photo To Folder
+
+## When to use
+
+Use this skill to place images into VMFO folders based on image content or user intent.
+
+## Required inputs
+
+- `attachment_id` from WordPress media upload.
+- Candidate topic label (for example: `Travel`, `Food`, `Team`).
+- Optional `parent_id` for hierarchical folder creation.
+
+## Procedure
+
+1. List folders first:
+   - Call `vmfo/list-folders` with `search` and inspect `path`.
+2. Resolve target folder:
+   - Prefer exact `path` match over raw `name`.
+3. Create folder when missing:
+   - Call `vmfo/create-folder` with `name` and `parent_id`.
+   - If create fails with permissions, stop and return actionable error.
+4. Assign image:
+   - Call `vmfo/add-to-folder` with resolved `folder_id` and `attachment_ids`.
+5. Return a compact result:
+   - `attachment_id`, `folder_id`, `folder_path`, `created` (boolean), `status`.
+
+## Tool calls
+
+All calls go through MCP adapter gateway tool:
+
+- `mcp-adapter-execute-ability` with:
+  - `ability_name: vmfo/list-folders`
+  - `ability_name: vmfo/create-folder`
+  - `ability_name: vmfo/add-to-folder`
+
+## Guardrails
+
+- Never create duplicate folder names blindly; check parent/path first.
+- Use `path` disambiguation when multiple folders share the same name.
+- Stop on permission errors; do not retry with guessed IDs.
+- Validate attachment IDs before assignment.
+
+## Failure handling
+
+- If list fails: return MCP/permission error.
+- If create fails with `term_exists`: re-run list and resolve by path.
+- If create fails with authorization: return that `manage_categories` is required.
+- If add fails: return folder and attachment IDs used for easier debugging.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to Virtual Media Folders will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2026-03-27
+
+### Added
+
+- `vmfo/create-folder` MCP ability with `name` and optional `parent_id` input, full folder payload output
+- MCP integration guide (`docs/mcp.md`): client configuration (Claude, GitHub Copilot, Cursor), upload-to-folder flow, troubleshooting
+- Agent skill for content-based image foldering (`.github/skills/add-photo-to-folder/SKILL.md`)
+
+### Changed
+
+- Smoke test script extended with optional mutating step (`VMFO_RUN_MUTATING_TESTS=1`) to cover `vmfo/create-folder`
+- `readme.txt` AI Abilities section updated to reflect three abilities and new permission model
+
 ## [2.0.2] - 2026-03-23
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -87,18 +87,21 @@ When inserting media from a block:
 Virtual Media Folders exposes Abilities API tools that can be used by AI agents and MCP adapters.
 
 - **`vmfo/list-folders`** (read-only): Lists folders with `id`, `name`, `parent_id`, `path`, and `count`.
+- **`vmfo/create-folder`** (write): Creates a folder with `name` and optional `parent_id`.
 - **`vmfo/add-to-folder`** (write): Adds one or more attachments to a folder using `folder_id` and `attachment_ids`.
 
 Recommended flow for AI clients:
 
 1. Call `vmfo/list-folders` to resolve folder names and paths to a stable `id`.
-2. Call `vmfo/add-to-folder` with that `folder_id` and one or more `attachment_ids`.
+2. If needed, call `vmfo/create-folder` to create the target folder.
+3. Call `vmfo/add-to-folder` with that `folder_id` and one or more `attachment_ids`.
 
 This avoids ambiguity when folder names are duplicated under different parents.
 
 Permission model:
 
-- Both abilities require the `upload_files` capability.
+- `vmfo/list-folders` and `vmfo/add-to-folder` require the `upload_files` capability.
+- `vmfo/create-folder` requires the `manage_categories` capability.
 
 WordPress MCP adapter (default server) example:
 
@@ -123,6 +126,12 @@ curl -X POST "https://example.com/wp-json/mcp/mcp-adapter-default-server" \
 	-u "username:application-password" \
 	-H "Content-Type: application/json" \
 	-d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"mcp-adapter-execute-ability","arguments":{"ability_name":"vmfo/add-to-folder","parameters":{"folder_id":2285,"attachment_ids":[101,205,309]}}}}'
+
+# Create folder via gateway
+curl -X POST "https://example.com/wp-json/mcp/mcp-adapter-default-server" \
+	-u "username:application-password" \
+	-H "Content-Type: application/json" \
+	-d '{"jsonrpc":"2.0","id":4,"method":"tools/call","params":{"name":"mcp-adapter-execute-ability","arguments":{"ability_name":"vmfo/create-folder","parameters":{"name":"Travel","parent_id":0}}}}'
 ```
 
 [Smoke test](./scripts/mcp-adapter-smoke-test.sh):
@@ -139,6 +148,7 @@ MCP_APP_PASS="xxxx xxxx xxxx xxxx xxxx xxxx" \
 - [Accessibility](docs/a11y.md) – Keyboard navigation and screen reader support
 - [Development](docs/development.md) – Setup, API reference, hooks, and contributing
 - [Add-on Development](docs/addon-development.md) – Guide to building add-on plugins
+- [MCP Integration](docs/mcp.md) – Upload, find/create folder, and assign media via MCP
 
 ## License
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -135,15 +135,17 @@ curl "https://example.com/wp-json/vmfo/v1/folders" \
 
 ## AI Abilities API
 
-Virtual Media Folders exposes two Abilities API tools for AI/MCP integrations:
+Virtual Media Folders exposes three Abilities API tools for AI/MCP integrations:
 
 - `vmfo/list-folders` (read-only)
+- `vmfo/create-folder` (write)
 - `vmfo/add-to-folder` (write)
 
 Recommended flow:
 
 1. Call `vmfo/list-folders` to resolve a folder name/path to a stable `id`.
-2. Call `vmfo/add-to-folder` with that `folder_id` and one or more `attachment_ids`.
+2. If no match exists, call `vmfo/create-folder`.
+3. Call `vmfo/add-to-folder` with that `folder_id` and one or more `attachment_ids`.
 
 ### Request/Response Examples
 
@@ -229,7 +231,10 @@ Recommended flow:
 }
 ```
 
-Both abilities require the `upload_files` capability.
+- `vmfo/list-folders` and `vmfo/add-to-folder` require the `upload_files` capability.
+- `vmfo/create-folder` requires the `manage_categories` capability.
+
+For full end-to-end examples (including image upload and editor client setup), see [mcp.md](mcp.md).
 
 ### WordPress MCP Adapter Examples
 
@@ -297,6 +302,29 @@ curl -X POST "https://example.com/wp-json/mcp/mcp-adapter-default-server" \
     }'
 ```
 
+Call `vmfo/create-folder` via the gateway tool (`mcp-adapter-execute-ability`):
+
+```bash
+curl -X POST "https://example.com/wp-json/mcp/mcp-adapter-default-server" \
+    -u "username:application-password" \
+    -H "Content-Type: application/json" \
+    -d '{
+        "jsonrpc": "2.0",
+        "id": 4,
+        "method": "tools/call",
+        "params": {
+            "name": "mcp-adapter-execute-ability",
+            "arguments": {
+                "ability_name": "vmfo/create-folder",
+                "parameters": {
+                    "name": "Travel",
+                    "parent_id": 0
+                }
+            }
+        }
+    }'
+```
+
 In practice, the AI flow is:
 
 1. `tools/call` -> `mcp-adapter-execute-ability` with `ability_name = vmfo/list-folders`
@@ -321,6 +349,7 @@ What it checks:
 2. `tools/list` includes `mcp-adapter-execute-ability`
 3. `vmfo/list-folders` executes via gateway and returns folder data
 4. `vmfo/add-to-folder` executes via gateway in safe negative mode (no data mutation)
+5. Optional: `vmfo/create-folder` executes via gateway in mutating mode
 
 ## Hooks & Filters
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,0 +1,224 @@
+# MCP Integration Guide
+
+This guide shows how to use MCP with Virtual Media Folders to:
+
+1. Upload an image.
+2. Find the best folder.
+3. Create the folder when missing.
+4. Add the image to the folder.
+
+## Prerequisites
+
+- WordPress with Virtual Media Folders active.
+- WordPress MCP Adapter active (default server).
+- A user with:
+  - `upload_files` for listing folders and assigning media.
+  - `manage_categories` for creating folders.
+- An Application Password for that user.
+
+Default MCP endpoint:
+
+`https://example.com/wp-json/mcp/mcp-adapter-default-server`
+
+## MCP Tools Exposed By This Plugin
+
+Virtual Media Folders exposes these abilities as MCP-compatible tools through the adapter gateway:
+
+- `vmfo/list-folders` (read-only)
+- `vmfo/create-folder` (write)
+- `vmfo/add-to-folder` (write)
+
+All calls are made through the gateway tool `mcp-adapter-execute-ability`.
+
+## Step 1: Upload The Image
+
+Upload is not handled by `vmfo/*` abilities. Use the WordPress media endpoint first:
+
+```bash
+curl -X POST "https://example.com/wp-json/wp/v2/media" \
+  -u "username:application-password" \
+  -H "Content-Disposition: attachment; filename=beach-sunset.jpg" \
+  -H "Content-Type: image/jpeg" \
+  --data-binary "@/absolute/path/beach-sunset.jpg"
+```
+
+Take the returned media `id` (for example `1234`).
+
+## Step 2: Discover Candidate Folder
+
+Call `tools/call` through the gateway and resolve folder IDs by path:
+
+```bash
+curl -X POST "https://example.com/wp-json/mcp/mcp-adapter-default-server" \
+  -u "username:application-password" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 2,
+    "method": "tools/call",
+    "params": {
+      "name": "mcp-adapter-execute-ability",
+      "arguments": {
+        "ability_name": "vmfo/list-folders",
+        "parameters": {
+          "search": "travel",
+          "hide_empty": false
+        }
+      }
+    }
+  }'
+```
+
+Use `path` to disambiguate duplicate names, then select the folder `id`.
+
+## Step 3: Create Folder If Missing
+
+If no matching folder exists, create one:
+
+```bash
+curl -X POST "https://example.com/wp-json/mcp/mcp-adapter-default-server" \
+  -u "username:application-password" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 3,
+    "method": "tools/call",
+    "params": {
+      "name": "mcp-adapter-execute-ability",
+      "arguments": {
+        "ability_name": "vmfo/create-folder",
+        "parameters": {
+          "name": "Travel",
+          "parent_id": 0
+        }
+      }
+    }
+  }'
+```
+
+Response includes `id`, `name`, `parent_id`, `path`, and `count`.
+
+## Step 4: Assign Uploaded Image To Folder
+
+Use the folder `id` from step 2 or 3 and the media `id` from step 1:
+
+```bash
+curl -X POST "https://example.com/wp-json/mcp/mcp-adapter-default-server" \
+  -u "username:application-password" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "jsonrpc": "2.0",
+    "id": 4,
+    "method": "tools/call",
+    "params": {
+      "name": "mcp-adapter-execute-ability",
+      "arguments": {
+        "ability_name": "vmfo/add-to-folder",
+        "parameters": {
+          "folder_id": 2285,
+          "attachment_ids": [1234]
+        }
+      }
+    }
+  }'
+```
+
+## One-Pass Agent Workflow
+
+For each image:
+
+1. Upload image and collect `attachment_id`.
+2. Run `vmfo/list-folders` with topic keywords.
+3. If folder missing, run `vmfo/create-folder`.
+4. Run `vmfo/add-to-folder` with `attachment_ids`.
+
+## Quick Client Configuration
+
+Configuration formats change over time across clients. Use these as templates and replace values.
+
+### Claude Desktop (MCP)
+
+```json
+{
+  "mcpServers": {
+    "vmfo": {
+      "type": "http",
+      "url": "https://example.com/wp-json/mcp/mcp-adapter-default-server",
+      "headers": {
+        "Authorization": "Basic <base64(username:application-password)>"
+      }
+    }
+  }
+}
+```
+
+### GitHub Copilot in VS Code
+
+1. Open Command Palette.
+2. Run `MCP: Add Server`.
+3. Choose HTTP server.
+4. Use endpoint `https://example.com/wp-json/mcp/mcp-adapter-default-server`.
+5. Add Basic auth header for your Application Password user.
+
+### Cursor
+
+Add an MCP HTTP server entry in Cursor MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "vmfo": {
+      "url": "https://example.com/wp-json/mcp/mcp-adapter-default-server",
+      "headers": {
+        "Authorization": "Basic <base64(username:application-password)>"
+      }
+    }
+  }
+}
+```
+
+## Skill: Auto-Place Photos By Image Content
+
+A reusable skill file is available at:
+
+`.github/skills/add-photo-to-folder/SKILL.md`
+
+It defines a deterministic flow that:
+
+1. Extracts a topic from image content.
+2. Finds matching folder paths.
+3. Creates a folder if allowed and needed.
+4. Assigns uploaded media IDs to the selected folder.
+
+## Troubleshooting
+
+- `401` or `403` on tools calls:
+  - Verify Application Password and user capabilities.
+  - `vmfo/create-folder` requires `manage_categories`.
+- Tool not found:
+  - Run `tools/list` first and confirm `mcp-adapter-execute-ability` exists.
+- Folder mismatch:
+  - Resolve by `path`, not only by `name`.
+- Upload succeeded but assignment failed:
+  - Confirm media ID is an attachment and folder ID exists.
+
+## Optional Smoke Test
+
+Run the included script:
+
+```bash
+MCP_BASE_URL="https://example.com/wp-json/mcp/mcp-adapter-default-server" \
+MCP_USER="per" \
+MCP_APP_PASS="xxxx xxxx xxxx xxxx xxxx xxxx" \
+./scripts/mcp-adapter-smoke-test.sh
+```
+
+Enable mutating create-folder test:
+
+```bash
+MCP_BASE_URL="https://example.com/wp-json/mcp/mcp-adapter-default-server" \
+MCP_USER="per" \
+MCP_APP_PASS="xxxx xxxx xxxx xxxx xxxx xxxx" \
+VMFO_RUN_MUTATING_TESTS=1 \
+./scripts/mcp-adapter-smoke-test.sh
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "virtual-media-folders",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Virtual folder organization and smart management for the WordPress Media Library.",
 	"scripts": {
 		"build": "wp-scripts build",

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: PerS
 Tags: media, ai, organization, media library, folders
 Requires at least: 6.8
 Tested up to: 7.0
-Stable tag: 2.0.2
+Stable tag: 2.0.3
 Requires PHP: 8.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -76,48 +76,29 @@ When inserting media from a block (Image, Gallery, etc.):
 Virtual Media Folders exposes Abilities API tools that can be used by AI agents and MCP adapters:
 
 * **`vmfo/list-folders`** (read-only) – Lists folders with `id`, `name`, `parent_id`, `path`, and `count`.
+* **`vmfo/create-folder`** (write) – Creates a folder with `name` and optional `parent_id`.
 * **`vmfo/add-to-folder`** (write) – Adds one or more attachments to a folder using `folder_id` and `attachment_ids`.
 
 Recommended AI flow:
 
 1. Call `vmfo/list-folders` to resolve folder names/paths to a stable `id`.
-2. Call `vmfo/add-to-folder` with that `folder_id` and one or more `attachment_ids`.
+2. If needed, call `vmfo/create-folder` to create the target folder.
+3. Call `vmfo/add-to-folder` with that `folder_id` and one or more `attachment_ids`.
 
 This avoids ambiguity when duplicate folder names exist.
 
 Permission model:
 
-* Both abilities require the `upload_files` capability.
+* `vmfo/list-folders` and `vmfo/add-to-folder` require the `upload_files` capability.
+* `vmfo/create-folder` requires the `manage_categories` capability.
 
-WordPress MCP adapter (default server) example:
-
-`
-# Endpoint:
-# /wp-json/mcp/mcp-adapter-default-server
-
-# List tools
-curl -X POST "https://example.com/wp-json/mcp/mcp-adapter-default-server" \
-	-u "username:application-password" \
-	-H "Content-Type: application/json" \
-	-d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'
-
-# Resolve folder id via gateway
-curl -X POST "https://example.com/wp-json/mcp/mcp-adapter-default-server" \
-	-u "username:application-password" \
-	-H "Content-Type: application/json" \
-	-d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"mcp-adapter-execute-ability","arguments":{"ability_name":"vmfo/list-folders","parameters":{"search":"travel","hide_empty":false}}}}'
-
-# Add attachments to folder via gateway
-curl -X POST "https://example.com/wp-json/mcp/mcp-adapter-default-server" \
-	-u "username:application-password" \
-	-H "Content-Type: application/json" \
-	-d '{"jsonrpc":"2.0","id":3,"method":"tools/call","params":{"name":"mcp-adapter-execute-ability","arguments":{"ability_name":"vmfo/add-to-folder","parameters":{"folder_id":2285,"attachment_ids":[101,205,309]}}}}'
-`
+See the [MCP Integration guide](https://github.com/soderlind/virtual-media-folders/blob/main/docs/mcp.md) for client configuration (Claude, GitHub Copilot, Cursor) and a full usage walkthrough.
 
 = Documentation =
 
 * [Accessibility](https://github.com/soderlind/virtual-media-folders/blob/main/docs/a11y.md) – Keyboard navigation and screen reader support
 * [Development](https://github.com/soderlind/virtual-media-folders/blob/main/docs/development.md) – Setup, API reference, hooks, and contributing
+* [MCP Integration](https://github.com/soderlind/virtual-media-folders/blob/main/docs/mcp.md) – MCP client configuration, upload flow, and AI agent usage
 * [Add-on Development](https://github.com/soderlind/virtual-media-folders/blob/main/docs/addon-development.md) – Guide to building add-on plugins
 
 = Free add-ons =
@@ -172,6 +153,12 @@ Only the folder organization is removed. Your media files are not deleted.
 Virtual Media Folders works entirely within the WordPress admin. It doesn't affect your front-end theme.
 
 == Changelog ==
+
+= 2.0.3 =
+* Added: `vmfo/create-folder` MCP ability (requires `manage_categories` capability)
+* Added: MCP integration guide (`docs/mcp.md`) with client configs for Claude, GitHub Copilot, and Cursor
+* Added: Agent skill for content-based image foldering (`.github/skills/add-photo-to-folder/SKILL.md`)
+* Changed: Smoke test script extended with optional mutating step (`VMFO_RUN_MUTATING_TESTS=1`)
 
 = 2.0.2 =
 * Fixed: Updated ability validator return type hints to `bool|WP_Error` for broader parser compatibility in release/pre-commit environments

--- a/scripts/mcp-adapter-smoke-test.sh
+++ b/scripts/mcp-adapter-smoke-test.sh
@@ -13,6 +13,9 @@ set -euo pipefail
 #   VMFO_SEARCH_TERM          Default: ""
 #   VMFO_TEST_ATTACHMENT_ID   Default: 101
 #   VMFO_EXPECT_DIRECT_TOOLS  Default: 0 (set 1 if your server exposes vmfo/* as direct MCP tools)
+#   VMFO_RUN_MUTATING_TESTS   Default: 0 (set 1 to run create-folder mutation test)
+#   VMFO_CREATE_FOLDER_NAME   Default: "MCP Smoke Test <timestamp>"
+#   VMFO_CREATE_PARENT_ID     Default: 0
 
 fail() {
     echo "[FAIL] $1" >&2
@@ -37,6 +40,9 @@ require_var "MCP_APP_PASS"
 VMFO_SEARCH_TERM="${VMFO_SEARCH_TERM:-}"
 VMFO_TEST_ATTACHMENT_ID="${VMFO_TEST_ATTACHMENT_ID:-101}"
 VMFO_EXPECT_DIRECT_TOOLS="${VMFO_EXPECT_DIRECT_TOOLS:-0}"
+VMFO_RUN_MUTATING_TESTS="${VMFO_RUN_MUTATING_TESTS:-0}"
+VMFO_CREATE_PARENT_ID="${VMFO_CREATE_PARENT_ID:-0}"
+VMFO_CREATE_FOLDER_NAME="${VMFO_CREATE_FOLDER_NAME:-MCP Smoke Test $(date +%s)}"
 AUTH="${MCP_USER}:${MCP_APP_PASS}"
 
 INIT_HEADERS="$(mktemp)"
@@ -74,6 +80,7 @@ pass "tools/list includes mcp-adapter-execute-ability"
 
 if [[ "$VMFO_EXPECT_DIRECT_TOOLS" == "1" ]]; then
     [[ "$TOOLS_LIST" == *"vmfo/list-folders"* ]] || fail "Expected direct vmfo/list-folders tool in tools/list"
+    [[ "$TOOLS_LIST" == *"vmfo/create-folder"* ]] || fail "Expected direct vmfo/create-folder tool in tools/list"
     [[ "$TOOLS_LIST" == *"vmfo/add-to-folder"* ]] || fail "Expected direct vmfo/add-to-folder tool in tools/list"
     pass "tools/list includes direct vmfo tools"
 else
@@ -103,6 +110,22 @@ ADD_CALL="$(curl -sS -X POST "$MCP_BASE_URL" \
 [[ "$ADD_CALL" == *"\"result\""* ]] || fail "vmfo/add-to-folder gateway call did not return result envelope"
 [[ "$ADD_CALL" == *"isError"* ]] || fail "vmfo/add-to-folder negative test did not return isError"
 pass "vmfo/add-to-folder gateway path executed (safe negative validation)"
+
+# 5) create-folder via gateway tool (optional mutating test)
+if [[ "$VMFO_RUN_MUTATING_TESTS" == "1" ]]; then
+    CREATE_PAYLOAD="{\"jsonrpc\":\"2.0\",\"id\":5,\"method\":\"tools/call\",\"params\":{\"name\":\"mcp-adapter-execute-ability\",\"arguments\":{\"ability_name\":\"vmfo/create-folder\",\"parameters\":{\"name\":\"${VMFO_CREATE_FOLDER_NAME}\",\"parent_id\":${VMFO_CREATE_PARENT_ID}}}}}"
+    CREATE_CALL="$(curl -sS -X POST "$MCP_BASE_URL" \
+        -u "$AUTH" \
+        -H "Content-Type: application/json" \
+        -H "Mcp-Session-Id: $SESSION_ID" \
+        -d "$CREATE_PAYLOAD")"
+
+    [[ "$CREATE_CALL" == *"\"result\""* ]] || fail "vmfo/create-folder gateway call did not return result"
+    [[ "$CREATE_CALL" == *"$VMFO_CREATE_FOLDER_NAME"* ]] || fail "vmfo/create-folder response does not include folder name"
+    pass "vmfo/create-folder gateway path executed (mutating mode)"
+else
+    pass "mutating create-folder test skipped (set VMFO_RUN_MUTATING_TESTS=1 to enable)"
+fi
 
 echo
 pass "MCP adapter smoke test completed"

--- a/src/AbilitiesIntegration.php
+++ b/src/AbilitiesIntegration.php
@@ -29,6 +29,11 @@ final class AbilitiesIntegration {
 	private const ADD_TO_FOLDER_ABILITY = 'vmfo/add-to-folder';
 
 	/**
+	 * Ability name for creating folders.
+	 */
+	private const CREATE_FOLDER_ABILITY = 'vmfo/create-folder';
+
+	/**
 	 * Read-only ability for folder discovery.
 	 */
 	private const LIST_FOLDERS_ABILITY = 'vmfo/list-folders';
@@ -229,6 +234,59 @@ final class AbilitiesIntegration {
 				],
 			]
 		);
+
+		wp_register_ability(
+			self::CREATE_FOLDER_ABILITY,
+			[
+				'label'               => __( 'Create Folder', 'virtual-media-folders' ),
+				'description'         => __( 'Creates a Virtual Media Folders folder with an optional parent.', 'virtual-media-folders' ),
+				'category'            => self::CATEGORY_SLUG,
+				'input_schema'        => [
+					'type'                 => 'object',
+					'properties'           => [
+						'name'      => [
+							'type'        => 'string',
+							'minLength'   => 1,
+							'description' => __( 'Folder name to create.', 'virtual-media-folders' ),
+						],
+						'parent_id' => [
+							'type'        => 'integer',
+							'minimum'     => 0,
+							'default'     => 0,
+							'description' => __( 'Optional parent folder ID.', 'virtual-media-folders' ),
+						],
+					],
+					'required'             => [ 'name' ],
+					'additionalProperties' => false,
+				],
+				'output_schema'       => [
+					'type'                 => 'object',
+					'properties'           => [
+						'id'        => [ 'type' => 'integer' ],
+						'name'      => [ 'type' => 'string' ],
+						'parent_id' => [ 'type' => 'integer' ],
+						'path'      => [ 'type' => 'string' ],
+						'count'     => [ 'type' => 'integer' ],
+					],
+					'required'             => [ 'id', 'name', 'parent_id', 'path', 'count' ],
+					'additionalProperties' => false,
+				],
+				'execute_callback'    => [ self::class, 'execute_create_folder' ],
+				'permission_callback' => [ self::class, 'can_create_folder' ],
+				'meta'                => [
+					'show_in_rest' => true,
+					'mcp'          => [
+						'public' => true,
+						'type'   => 'tool',
+					],
+					'annotations'  => [
+						'readonly'    => false,
+						'destructive' => false,
+						'idempotent'  => false,
+					],
+				],
+			]
+		);
 	}
 
 	/**
@@ -267,6 +325,26 @@ final class AbilitiesIntegration {
 		return new WP_Error(
 			'rest_forbidden',
 			__( 'You are not allowed to view folders.', 'virtual-media-folders' ),
+			[ 'status' => rest_authorization_required_code() ]
+		);
+	}
+
+	/**
+	 * Check whether the current user can create folders.
+	 *
+	 * @param array<string, mixed>|null $input Ability input.
+	 * @return bool|WP_Error
+	 */
+	public static function can_create_folder( ?array $input = null ): bool|WP_Error {
+		unset( $input );
+
+		if ( current_user_can( 'manage_categories' ) ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'You are not allowed to create folders.', 'virtual-media-folders' ),
 			[ 'status' => rest_authorization_required_code() ]
 		);
 	}
@@ -330,6 +408,84 @@ final class AbilitiesIntegration {
 		return [
 			'folders' => $folders,
 			'total'   => count( $folders ),
+		];
+	}
+
+	/**
+	 * Execute create-folder ability.
+	 *
+	 * @param array<string, mixed> $input Ability input.
+	 * @return array<string, mixed>|WP_Error
+	 */
+	public static function execute_create_folder( array $input ): array|WP_Error {
+		$name      = isset( $input['name'] ) ? trim( (string) $input['name'] ) : '';
+		$parent_id = absint( $input['parent_id'] ?? 0 );
+
+		if ( '' === $name ) {
+			return new WP_Error(
+				'ability_invalid_input',
+				__( 'A non-empty folder name is required.', 'virtual-media-folders' )
+			);
+		}
+
+		if ( $parent_id > 0 ) {
+			$parent_validation = self::validate_folder( $parent_id );
+			if ( is_wp_error( $parent_validation ) ) {
+				return new WP_Error(
+					'parent_not_exists',
+					__( 'Parent folder does not exist.', 'virtual-media-folders' ),
+					[ 'status' => 400 ]
+				);
+			}
+		}
+
+		$result = wp_insert_term(
+			$name,
+			Taxonomy::TAXONOMY,
+			[
+				'parent' => $parent_id,
+			]
+		);
+
+		if ( is_wp_error( $result ) ) {
+			$error_code = $result->get_error_code();
+
+			$error_messages = [
+				'term_exists'       => __( 'A folder with this name already exists.', 'virtual-media-folders' ),
+				'empty_term_name'   => __( 'Folder name cannot be empty.', 'virtual-media-folders' ),
+				'invalid_term'      => __( 'Invalid folder.', 'virtual-media-folders' ),
+				'invalid_taxonomy'  => __( 'Invalid folder taxonomy.', 'virtual-media-folders' ),
+				'parent_not_exists' => __( 'Parent folder does not exist.', 'virtual-media-folders' ),
+			];
+
+			$message = $error_messages[ $error_code ] ?? $result->get_error_message();
+
+			return new WP_Error(
+				$error_code,
+				$message,
+				[ 'status' => 400 ]
+			);
+		}
+
+		$folder = get_term( $result['term_id'], Taxonomy::TAXONOMY );
+		if ( is_wp_error( $folder ) || ! $folder ) {
+			return new WP_Error(
+				'rest_folder_not_found',
+				__( 'Folder not found.', 'virtual-media-folders' ),
+				[ 'status' => 404 ]
+			);
+		}
+
+		$term_cache = [
+			(int) $folder->term_id => $folder,
+		];
+
+		return [
+			'id'        => (int) $folder->term_id,
+			'name'      => (string) $folder->name,
+			'parent_id' => (int) $folder->parent,
+			'path'      => self::build_folder_path( $folder, $term_cache ),
+			'count'     => (int) $folder->count,
 		];
 	}
 

--- a/tests/php/AbilitiesIntegrationTest.php
+++ b/tests/php/AbilitiesIntegrationTest.php
@@ -82,6 +82,7 @@ class AbilitiesIntegrationTest extends TestCase {
 		AbilitiesIntegration::register_abilities();
 
 		$this->assertArrayHasKey( 'vmfo/list-folders', $GLOBALS['vmfo_registered_abilities'] );
+		$this->assertArrayHasKey( 'vmfo/create-folder', $GLOBALS['vmfo_registered_abilities'] );
 		$this->assertArrayHasKey( 'vmfo/add-to-folder', $GLOBALS['vmfo_registered_abilities'] );
 
 		$list_args = $GLOBALS['vmfo_registered_abilities']['vmfo/list-folders'];
@@ -93,6 +94,17 @@ class AbilitiesIntegrationTest extends TestCase {
 		$this->assertTrue( $list_args['meta']['annotations']['readonly'] );
 		$this->assertIsCallable( $list_args['execute_callback'] );
 		$this->assertIsCallable( $list_args['permission_callback'] );
+
+		$create_args = $GLOBALS['vmfo_registered_abilities']['vmfo/create-folder'];
+
+		$this->assertSame( 'vmfo-folder-management', $create_args['category'] );
+		$this->assertTrue( $create_args['meta']['show_in_rest'] );
+		$this->assertTrue( $create_args['meta']['mcp']['public'] );
+		$this->assertSame( 'tool', $create_args['meta']['mcp']['type'] );
+		$this->assertFalse( $create_args['meta']['annotations']['readonly'] );
+		$this->assertFalse( $create_args['meta']['annotations']['idempotent'] );
+		$this->assertIsCallable( $create_args['execute_callback'] );
+		$this->assertIsCallable( $create_args['permission_callback'] );
 
 		$args = $GLOBALS['vmfo_registered_abilities']['vmfo/add-to-folder'];
 
@@ -130,6 +142,94 @@ class AbilitiesIntegrationTest extends TestCase {
 
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * Test create-folder permission success.
+	 */
+	public function test_can_create_folder_allows_category_managers(): void {
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'manage_categories' )
+			->andReturn( true );
+
+		$this->assertTrue( AbilitiesIntegration::can_create_folder() );
+	}
+
+	/**
+	 * Test create-folder permission failure.
+	 */
+	public function test_can_create_folder_returns_wp_error_when_capability_missing(): void {
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'manage_categories' )
+			->andReturn( false );
+
+		$result = AbilitiesIntegration::can_create_folder();
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'rest_forbidden', $result->get_error_code() );
+	}
+
+	/**
+	 * Test successful folder creation.
+	 */
+	public function test_execute_create_folder_returns_folder_payload(): void {
+		Functions\when( 'get_term' )->alias(
+			static function ( int $term_id, string $taxonomy ) {
+				if ( 9 === $term_id ) {
+					return (object) [
+						'term_id'  => 9,
+						'taxonomy' => $taxonomy,
+						'name'     => 'Travel',
+						'parent'   => 0,
+						'count'    => 0,
+					];
+				}
+
+				return null;
+			}
+		);
+		Functions\when( 'wp_insert_term' )->alias(
+			static fn( string $name, string $taxonomy, array $args ) => [
+				'term_id'          => 9,
+				'term_taxonomy_id' => 9,
+			]
+		);
+
+		$result = AbilitiesIntegration::execute_create_folder(
+			[
+				'name'      => 'Travel',
+				'parent_id' => 0,
+			]
+		);
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 9, $result['id'] );
+		$this->assertSame( 'Travel', $result['name'] );
+		$this->assertSame( 0, $result['parent_id'] );
+		$this->assertSame( 'Travel', $result['path'] );
+		$this->assertSame( 0, $result['count'] );
+	}
+
+	/**
+	 * Test create-folder duplicate mapping.
+	 */
+	public function test_execute_create_folder_maps_term_exists_error(): void {
+		Functions\when( 'wp_insert_term' )->justReturn(
+			new \WP_Error( 'term_exists', 'Term exists.' )
+		);
+
+		$result = AbilitiesIntegration::execute_create_folder(
+			[
+				'name'      => 'Travel',
+				'parent_id' => 0,
+			]
+		);
+
+		$this->assertInstanceOf( \WP_Error::class, $result );
+		$this->assertSame( 'term_exists', $result->get_error_code() );
+		$this->assertSame( 'A folder with this name already exists.', $result->get_error_message() );
 	}
 
 	/**

--- a/virtual-media-folders.php
+++ b/virtual-media-folders.php
@@ -14,7 +14,7 @@
  * @wordpress-plugin
  * Plugin Name: Virtual Media Folders
  * Description: Virtual folder organization and smart management for the WordPress Media Library.
- * Version: 2.0.2
+ * Version: 2.0.3
  * Requires at least: 6.8
  * Requires PHP: 8.3
  * Author: Per Soderlind


### PR DESCRIPTION
This pull request introduces the new `vmfo/create-folder` ability to Virtual Media Folders, expands MCP/AI integration documentation, and enhances testing and agent skills for automated image organization. The update adds full support for folder creation via the MCP adapter, provides a detailed integration guide for AI clients (Claude, GitHub Copilot, Cursor), and includes an agent skill for content-based image foldering. The smoke test script now optionally covers folder creation, and documentation has been updated throughout to reflect these changes.

**New features and abilities:**

* Added the `vmfo/create-folder` MCP ability, enabling folder creation with `name` and optional `parent_id` parameters, and requiring the `manage_categories` capability. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R90-R104) [[2]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeL138-R148) [[3]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeR305-R327) [[4]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R79-R101) [[5]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R157-R162) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R20)
* Introduced an agent skill for content-based image foldering in `.github/skills/add-photo-to-folder/SKILL.md`, outlining a deterministic flow for AI agents to organize images. [[1]](diffhunk://#diff-d86db79fb725ef863b6ff1dfcca8ba93a8e74b346d40c18699760ae4bb25cbdbR1-R53) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R20)

**Documentation and integration improvements:**

* Added a comprehensive MCP integration guide (`docs/mcp.md`) detailing client configuration, upload-to-folder workflow, and troubleshooting for AI/MCP clients. [[1]](diffhunk://#diff-540fac6ea007bc938b77f99fe1f0766cf1ab7628ffed1d2830327fb2dab88c28R1-R224) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R151) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R79-R101)
* Updated `README.md`, `readme.txt`, and `docs/development.md` to document the new ability, revised permission model, and provide concrete examples for all MCP abilities. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R90-R104) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R129-R134) [[3]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeL138-R148) [[4]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeL232-R237) [[5]](diffhunk://#diff-97db29a7915320e63d41d38a0440360a87055ee8ed03757aa263116dbbb4aabeR352) [[6]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R79-R101) [[7]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R157-R162)

**Testing enhancements:**

* Extended the smoke test script (`scripts/mcp-adapter-smoke-test.sh`) to optionally run a mutating test for folder creation, controlled by the `VMFO_RUN_MUTATING_TESTS` environment variable. [[1]](diffhunk://#diff-23d6919ea77fe8ed265dcf892d5fb0665f4d2ecc365aee025d4402cd154aedc0R16-R18) [[2]](diffhunk://#diff-23d6919ea77fe8ed265dcf892d5fb0665f4d2ecc365aee025d4402cd154aedc0R43-R45) [[3]](diffhunk://#diff-23d6919ea77fe8ed265dcf892d5fb0665f4d2ecc365aee025d4402cd154aedc0R83) [[4]](diffhunk://#diff-23d6919ea77fe8ed265dcf892d5fb0665f4d2ecc365aee025d4402cd154aedc0R114-R129) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R20)

**Other changes:**

* Bumped the version to `2.0.3` in `package.json` and `readme.txt`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6)
* Updated changelog to reflect all new features and documentation.