### PR TITLE
docs: update MCP Integration guide links to point to the AI Ability add-on

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -94,13 +94,13 @@ Permission model:
 * `vmfo/list-folders` and `vmfo/add-to-folder` require the `upload_files` capability.
 * `vmfo/create-folder` requires the `manage_categories` capability.
 
-See the [MCP Integration guide](https://github.com/soderlind/virtual-media-folders/blob/main/docs/mcp.md) for client configuration (Claude, GitHub Copilot, Cursor) and a full usage walkthrough.
+See the [MCP Integration guide](https://github.com/soderlind/vmfa-ai-ability/blob/main/docs/mcp.md) for client configuration (Claude, GitHub Copilot, Cursor) and a full usage walkthrough.
 
 = Documentation =
 
 * [Accessibility](https://github.com/soderlind/virtual-media-folders/blob/main/docs/a11y.md) – Keyboard navigation and screen reader support
 * [Development](https://github.com/soderlind/virtual-media-folders/blob/main/docs/development.md) – Setup, API reference, hooks, and contributing
-* [MCP Integration](https://github.com/soderlind/virtual-media-folders/blob/main/docs/mcp.md) – MCP client configuration, upload flow, and AI agent usage
+* [MCP Integration](https://github.com/soderlind/vmfa-ai-ability/blob/main/docs/mcp.md) – MCP client configuration, upload flow, and AI agent usage using the [AI Ability](https://github.com/soderlind/vmfa-ai-ability) add-on
 * [Add-on Development](https://github.com/soderlind/virtual-media-folders/blob/main/docs/addon-development.md) – Guide to building add-on plugins
 
 = Free add-ons =


### PR DESCRIPTION
This pull request updates the `readme.txt` documentation to reference the correct repository for the MCP Integration guide and clarifies the usage of the AI Ability add-on. These changes ensure users are directed to the appropriate resources for client configuration and integration.

Documentation updates:

* Updated the MCP Integration guide links to point to the `vmfa-ai-ability` repository instead of `virtual-media-folders`, ensuring users access the correct documentation.
* Clarified that the AI agent usage is provided via the [AI Ability](https://github.com/soderlind/vmfa-ai-ability) add-on in the documentation.