### PR TITLE
Fix Gutenberg gallery-edit selection reset when VMFO is active

### DIFF
--- a/src/editor/index.js
+++ b/src/editor/index.js
@@ -100,6 +100,12 @@ function initGutenbergIntegration() {
 	wp.media.view.AttachmentsBrowser.prototype.render = function () {
 		originalRender.apply(this, arguments);
 
+		const mediaState = this.controller?.state?.();
+		const mediaStateId = mediaState?.id || mediaState?.get?.('id');
+		if (mediaStateId === 'gallery-edit') {
+			return this;
+		}
+
 		// Only add sidebar if not already present
 		if (!this.$el.find('.vmf-editor-folder-sidebar').length) {
 			// Find the attachments container


### PR DESCRIPTION
## Summary
- skip VMFO sidebar/filter injection when the media modal state is `gallery-edit`
- prevent the gallery selection collection from being reset in that state

## Problem
With VMFO active, Gallery block creation could end up with an empty selection in `gallery-edit` and a disabled insert button.

## Root cause
The `AttachmentsBrowser` render override was applying VMFO sidebar behavior in gallery-edit context, where collection mutations interfere with gallery state.

## Fix
Early-return from the VMFO sidebar injection path when `controller.state().id === 'gallery-edit'`.

Closes #114

Co-Authored-By: Oz <oz-agent@warp.dev>